### PR TITLE
feat: import core of highlightjs without all languages

### DIFF
--- a/src/transform/highlight.ts
+++ b/src/transform/highlight.ts
@@ -1,18 +1,19 @@
+import type {HLJSApi} from 'highlight.js';
 import {escapeHtml} from 'markdown-it/lib/common/utils';
-import {HighlightLangMap} from './typings';
+import type {HighlightLangMap} from './typings';
 
 export = function makeHighlight(langs: HighlightLangMap = {}) {
     try {
         // Important require.
         // Because we want to have a posibility to run in projects without hljs dependency
-        const hljs = require('highlight.js');
+        const hljs: HLJSApi = require('highlight.js/lib/core');
 
         Object.keys(langs).forEach((lang) => {
             hljs.registerLanguage(lang, langs[lang]);
         });
 
         return function highlight(str: string, lang: string) {
-            let highlightedStr;
+            let highlightedStr: string | undefined;
             const classNames = ['hljs'];
 
             if (lang && hljs.getLanguage(lang)) {

--- a/src/transform/typings.ts
+++ b/src/transform/typings.ts
@@ -1,10 +1,10 @@
-import {LanguageFn} from 'highlight.js';
-import DefaultMarkdownIt from 'markdown-it';
-import DefaultStateCore from 'markdown-it/lib/rules_core/state_core';
-import {SanitizeOptions} from './sanitize';
-import {MarkdownItPluginCb} from './plugins/typings';
-import {LogLevels} from './log';
-import {ChangelogItem} from './plugins/changelog/types';
+import type {LanguageFn} from 'highlight.js';
+import type DefaultMarkdownIt from 'markdown-it';
+import type DefaultStateCore from 'markdown-it/lib/rules_core/state_core';
+import type {SanitizeOptions} from './sanitize';
+import type {MarkdownItPluginCb} from './plugins/typings';
+import type {LogLevels} from './log';
+import type {ChangelogItem} from './plugins/changelog/types';
 
 export interface MarkdownIt extends DefaultMarkdownIt {
     assets?: string[];

--- a/test/highlight-code.test.ts
+++ b/test/highlight-code.test.ts
@@ -1,4 +1,5 @@
-import {dirname} from 'path';
+import {dirname} from 'node:path';
+import typescript from 'highlight.js/lib/languages/typescript';
 import transform from '../src/transform';
 
 const mocksPath = require.resolve('./utils.ts');
@@ -7,6 +8,7 @@ const transformYfm = (text: string) => {
         result: {html},
     } = transform(text, {
         plugins: [],
+        highlightLangs: {ts: typescript},
         path: mocksPath,
         root: dirname(mocksPath),
     });


### PR DESCRIPTION
When import main package (`highlight.js`), all avalilable languages are loaded automatically.

To import only core we need to import from `highlight.js/lib/core`

For more information see docs: https://highlightjs.org/#as-a-module