### PR TITLE
fix: correct nested ol indexing in firefox

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -294,7 +294,7 @@
     &:not(.yfm_no-list-reset) {
         ol {
             list-style-type: none;
-            counter-reset: list;
+            counter-reset: list-item;
 
             & > li {
                 position: relative;


### PR DESCRIPTION
resolve #149