### PR TITLE
fix: reset ordered lists inside cuts

### DIFF
--- a/src/scss/_cut.scss
+++ b/src/scss/_cut.scss
@@ -37,6 +37,18 @@
             transform: translateY(-50%);
         }
     }
+
+    .yfm:not(.yfm_no-list-reset) & ol {
+        counter-reset: cut-list;
+
+        & > li {
+            counter-increment: cut-list;
+
+            &::before {
+                content: counters(cut-list, '.') '. ';
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
Hi!

I added styles for lists inside cuts similar to tabs styles. 

It resolves https://github.com/diplodoc-platform/cli/issues/145.

___
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.