### PR TITLE
fix: add `object-fit: contain` for images

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -89,6 +89,7 @@
     }
 
     img {
+        object-fit: contain;
         background-color: $baseColor;
     }
 


### PR DESCRIPTION
To make them keep the aspect ration when resizing

https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit