### PR TITLE
fix: terms extend beyond right edge of screen

### DIFF
--- a/src/js/term/utils.ts
+++ b/src/js/term/utils.ts
@@ -87,7 +87,9 @@ export function setDefinitionPosition(
         isAlignSwapped && !definitionOutOfScreenOnLeft ? definitionWidth - termWidth : 0;
     const customHeaderTop = getCoords(definitionParent).top - definitionParent.offsetTop;
     const offsetRight = 5;
-    const shiftLeft = definitionOutOfScreenOnRight ? definitionRightCoordinate - document.body.clientWidth + offsetRight : 0;
+    const shiftLeft = definitionOutOfScreenOnRight
+        ? definitionRightCoordinate - document.body.clientWidth + offsetRight
+        : 0;
     const offsetLeft =
         getCoords(termElement).left -
         definitionParentLeft +
@@ -99,7 +101,7 @@ export function setDefinitionPosition(
     definitionElement.style.top =
         Number(getCoords(termElement).top + offsetTop - customHeaderTop) + 'px';
     definitionElement.style.left = Number(offsetLeft - (isShiftLeftNeeded ? shiftLeft : 0)) + 'px';
-
+}
 
 function termOnResize() {
     const openDefinition = document.getElementsByClassName(openDefinitionClass)[0] as HTMLElement;

--- a/src/js/term/utils.ts
+++ b/src/js/term/utils.ts
@@ -89,18 +89,18 @@ export function setDefinitionPosition(
     
     const offsetRight = 5
     const shiftLeft = definitionOutOfScreenOnRight ? (definitionRightCoordinate - document.body.clientWidth + offsetRight) : 0
-    const leftOffset =
+    const offsetLeft =
         getCoords(termElement).left -
         definitionParentLeft +
         definitionParent.offsetLeft -
         fitDefinitionDocument
 
-    const isShiftLeftNeeded = leftOffset + definitionWidth >= document.body.clientWidth;
+    const isShiftLeftNeeded = offsetLeft + definitionWidth >= document.body.clientWidth;
 
     definitionElement.style.top =
         Number(getCoords(termElement).top + offsetTop - customHeaderTop) + 'px';
     definitionElement.style.left = Number(
-        leftOffset -
+        offsetLeft -
         (isShiftLeftNeeded ? shiftLeft : 0)
     ) + 'px';
 }

--- a/src/js/term/utils.ts
+++ b/src/js/term/utils.ts
@@ -86,16 +86,23 @@ export function setDefinitionPosition(
     const fitDefinitionDocument =
         isAlignSwapped && !definitionOutOfScreenOnLeft ? definitionWidth - termWidth : 0;
     const customHeaderTop = getCoords(definitionParent).top - definitionParent.offsetTop;
+    
+    const offsetRight = 5
+    const shiftLeft = definitionOutOfScreenOnRight ? (definitionRightCoordinate - document.body.clientWidth + offsetRight) : 0
+    const leftOffset =
+        getCoords(termElement).left -
+        definitionParentLeft +
+        definitionParent.offsetLeft -
+        fitDefinitionDocument
+
+    const isShiftLeftNeeded = leftOffset + definitionWidth >= document.body.clientWidth;
 
     definitionElement.style.top =
         Number(getCoords(termElement).top + offsetTop - customHeaderTop) + 'px';
-    definitionElement.style.left =
-        Number(
-            getCoords(termElement).left -
-                definitionParentLeft +
-                definitionParent.offsetLeft -
-                fitDefinitionDocument,
-        ) + 'px';
+    definitionElement.style.left = Number(
+        leftOffset -
+        (isShiftLeftNeeded ? shiftLeft : 0)
+    ) + 'px';
 }
 
 function termOnResize() {


### PR DESCRIPTION
Fixed a bug where the term pop-up window would extend beyond the edge of the screen on mobile devices.