### PR TITLE
fix: pop-up definition overlaps header

### DIFF
--- a/src/scss/_term.scss
+++ b/src/scss/_term.scss
@@ -16,7 +16,7 @@
 
     &_dfn {
         position: absolute;
-        z-index: 1000;
+        z-index: 100;
 
         width: fit-content;
         max-width: 450px;


### PR DESCRIPTION
The pop-up of the terms overlapped the header. Previously, changes were made to @diplodoc/client 
to solve the problem, with ref: https://github.com/diplodoc-platform/client/pull/51

The changes caused new bug and it was decided to fix the initial bug in another way 
by changing the z-index of the terms themselves.