### PR TITLE
Make term popup more accessible

### DIFF
--- a/src/js/term/index.ts
+++ b/src/js/term/index.ts
@@ -6,6 +6,7 @@ import {
     openDefinitionClass,
     setDefinitionId,
     setDefinitionPosition,
+    setDefinitonAriaLive,
 } from './utils';
 import {getEventTarget, isCustom} from '../utils';
 
@@ -43,6 +44,7 @@ if (typeof document !== 'undefined') {
         }
 
         setDefinitionId(definitionElement, target);
+        setDefinitonAriaLive(definitionElement, target);
         setDefinitionPosition(definitionElement, target);
 
         definitionElement.classList.toggle(openClass);

--- a/src/js/term/utils.ts
+++ b/src/js/term/utils.ts
@@ -24,6 +24,14 @@ export function setDefinitionId(definitionElement: HTMLElement, termElement: HTM
     definitionElement?.setAttribute('term-id', termId);
 }
 
+export function setDefinitonAriaLive(
+    definitionElement: HTMLElement,
+    termElement: HTMLElement,
+): void {
+    const ariaLive = termElement.getAttribute('aria-live') || 'polite';
+    definitionElement?.setAttribute('aria-live', ariaLive);
+}
+
 export function setDefinitionPosition(
     definitionElement: HTMLElement,
     termElement: HTMLElement,

--- a/src/transform/plugins/term/termDefinitions.ts
+++ b/src/transform/plugins/term/termDefinitions.ts
@@ -141,6 +141,7 @@ function processTermDefinition(
     token.attrSet('class', 'yfm yfm-term_dfn');
     token.attrSet('id', ':' + label + '_element');
     token.attrSet('role', 'tooltip');
+    token.attrSet('aria-live', 'polite');
 
     state.tokens.push(token);
 


### PR DESCRIPTION
Task: https://github.com/orgs/diplodoc-platform/projects/2/views/1?pane=issue&itemId=55495835

1) "role" attribute for term popup already exists (role='tooltip');
2) add "aria-live" attribute for term popup.

Before adding "aria-live":

https://github.com/user-attachments/assets/2e978eb1-bf03-46eb-8071-b23ccd4902b1

After:   

https://github.com/user-attachments/assets/ab19e728-441b-4aa6-88ca-9452057bb124

