### PR TITLE
Use <details> tag for cuts

### DIFF
--- a/src/scss/_cut.scss
+++ b/src/scss/_cut.scss
@@ -1,20 +1,28 @@
 .yfm-cut {
     $class: &;
-    
     margin-bottom: 15px;
 
     &-title {
+        list-style: none;
         cursor: pointer;
         position: relative;
         user-select: none;
         padding: 5px 0 5px 30px;
+
+        &::-webkit-details-marker {
+            display: none;
+        }
+
+        &:focus {
+            outline-color: $accentColor;
+        }
 
         &:before {
             content: '';
             z-index: 1;
             left: 0;
             top: 50%;
-            background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+CiAgICA8cGF0aCBzdHJva2U9ImN1cnJlbnRDb2xvciIgZmlsbD0ibm9uZSIgZD0iTTMgNmw1IDUgNS01Ii8+Cjwvc3ZnPgo=");
+            background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+CiAgICA8cGF0aCBzdHJva2U9ImN1cnJlbnRDb2xvciIgZmlsbD0ibm9uZSIgZD0iTTMgNmw1IDUgNS01Ii8+Cjwvc3ZnPgo=');
             transform: translateY(-50%) rotate(-90deg);
             transition: transform 0.3s ease;
             height: 20px;
@@ -24,17 +32,10 @@
     }
 
     &-content {
-        display: none;
-        overflow: hidden;
-        transition: height 0.3s ease-in-out;
+        padding: 5px 0 15px 30px;
     }
 
     &.open {
-        > #{$class}-content {
-            display: revert;
-            padding: 5px 0 15px 30px;
-        }
-
         > #{$class}-title:before {
             transform: translateY(-50%);
         }
@@ -52,5 +53,3 @@
         }
     }
 }
-
-

--- a/src/transform/plugins/cut.ts
+++ b/src/transform/plugins/cut.ts
@@ -39,11 +39,11 @@ const cut: MarkdownItPluginCb = (md, {path, log}) => {
                     continue;
                 }
 
-                const newOpenToken = new state.Token('yfm_cut_open', 'div', 1);
+                const newOpenToken = new state.Token('yfm_cut_open', 'details', 1);
                 newOpenToken.attrSet('class', 'yfm-cut');
                 newOpenToken.map = tokens[i].map;
 
-                const titleOpen = new state.Token('yfm_cut_title_open', 'div', 1);
+                const titleOpen = new state.Token('yfm_cut_title_open', 'summary', 1);
                 titleOpen.attrSet('class', 'yfm-cut-title');
 
                 const titleInline = state.md.parseInline(
@@ -51,7 +51,7 @@ const cut: MarkdownItPluginCb = (md, {path, log}) => {
                     state.env,
                 )[0];
 
-                const titleClose = new state.Token('yfm_cut_title_close', 'div', -1);
+                const titleClose = new state.Token('yfm_cut_title_close', 'summary', -1);
 
                 const contentOpen = new state.Token('yfm_cut_content_open', 'div', 1);
                 contentOpen.attrSet('class', 'yfm-cut-content');
@@ -65,7 +65,7 @@ const cut: MarkdownItPluginCb = (md, {path, log}) => {
 
                 const contentClose = new state.Token('yfm_cut_content_close', 'div', -1);
 
-                const newCloseToken = new state.Token('yfm_cut_close', 'div', -1);
+                const newCloseToken = new state.Token('yfm_cut_close', 'details', -1);
                 newCloseToken.map = tokens[closeTokenIdx].map;
 
                 const insideTokens = [

--- a/test/cut.test.ts
+++ b/test/cut.test.ts
@@ -17,9 +17,10 @@ describe('Cut plugin', () => {
                 '{% cut "Cut title" %}\n' + '\n' + 'Cut content\n' + '\n' + '{% endcut %}',
             ).replace(/(\r\n|\n|\r)/gm, ''),
         ).toBe(
-            '<div class="yfm-cut"><div class="yfm-cut-title">Cut title</div>' +
-                '<div class="yfm-cut-content"><p>Cut content</p>' +
-                '</div></div>',
+            '<details class="yfm-cut">' +
+                '<summary class="yfm-cut-title">Cut title</summary>' +
+                '<div class="yfm-cut-content"><p>Cut content</p></div>' +
+                '</details>',
         );
     });
 
@@ -35,9 +36,12 @@ describe('Cut plugin', () => {
                     '{% endcut %}',
             ).replace(/(\r\n|\n|\r)/gm, ''),
         ).toBe(
-            '<div class="yfm-cut"><div class="yfm-cut-title">Cut title</div>' +
-                '<div class="yfm-cut-content"><pre><code class="hljs">Code</code></pre>' +
-                '</div></div>',
+            '<details class="yfm-cut">' +
+                '<summary class="yfm-cut-title">Cut title</summary>' +
+                '<div class="yfm-cut-content">' +
+                '<pre><code class="hljs">Code</code></pre>' +
+                '</div>' +
+                '</details>',
         );
     });
 
@@ -57,12 +61,15 @@ describe('Cut plugin', () => {
                     '{% endcut %}',
             ).replace(/(\r\n|\n|\r)/gm, ''),
         ).toBe(
-            '<div class="yfm-cut"><div class="yfm-cut-title">Cut title 1</div>' +
-                '<div class="yfm-cut-content"><p>Cut content 1</p></div>' +
-                '</div>' +
-                '<div class="yfm-cut"><div class="yfm-cut-title">Cut title 2</div>' +
-                '<div class="yfm-cut-content"><p>Cut content 2</p></div>' +
-                '</div>',
+            '<details class="yfm-cut">' +
+                '<summary class="yfm-cut-title">Cut title 1</summary>' +
+                '<div class="yfm-cut-content"><p>Cut content 1</p>' +
+                '</div></details>' +
+                '<details class="yfm-cut">' +
+                '<summary class="yfm-cut-title">Cut title 2</summary>' +
+                '<div class="yfm-cut-content">' +
+                '<p>Cut content 2</p>' +
+                '</div></details>',
         );
     });
 
@@ -82,11 +89,12 @@ describe('Cut plugin', () => {
                     '{% endcut %}',
             ).replace(/(\r\n|\n|\r)/gm, ''),
         ).toBe(
-            '<div class="yfm-cut"><div class="yfm-cut-title">Outer title</div>' +
-                '<div class="yfm-cut-content"><p>Outer content</p>' +
-                '<div class="yfm-cut"><div class="yfm-cut-title">Inner title</div>' +
-                '<div class="yfm-cut-content"><p>Inner content</p></div>' +
-                '</div></div></div>',
+            '<details class="yfm-cut"><summary class="yfm-cut-title">' +
+                'Outer title</summary><div class="yfm-cut-content">' +
+                '<p>Outer content</p><details class="yfm-cut">' +
+                '<summary class="yfm-cut-title">Inner title</summary>' +
+                '<div class="yfm-cut-content"><p>Inner content</p>' +
+                '</div></details></div></details>',
         );
     });
 
@@ -100,10 +108,11 @@ describe('Cut plugin', () => {
                     '{% endcut %}',
             ).replace(/(\r\n|\n|\r)/gm, ''),
         ).toBe(
-            '<div class="yfm-cut">' +
-                '<div class="yfm-cut-title"><strong>Strong cut title</strong></div>' +
-                '<div class="yfm-cut-content"><p>Content we want to hide</p></div>' +
-                '</div>',
+            '<details class="yfm-cut"><summary class="yfm-cut-title">' +
+                '<strong>Strong cut title</strong>' +
+                '</summary><div class="yfm-cut-content">' +
+                '<p>Content we want to hide</p>' +
+                '</div></details>',
         );
     });
 
@@ -119,8 +128,11 @@ describe('Cut plugin', () => {
                     '{% endcut %}',
             ).replace(/(\r\n|\n|\r)/gm, ''),
         ).toBe(
-            '<ul><li><div class="yfm-cut"><div class="yfm-cut-title">Cut 1</div>' +
-                '<div class="yfm-cut-content"><p>Some text</p><p>Some text</p></div></div></li></ul>',
+            '<ul><li>' +
+                '<details class="yfm-cut"><summary class="yfm-cut-title">Cut 1</summary>' +
+                '<div class="yfm-cut-content"><p>Some text</p>' +
+                '<p>Some text</p>' +
+                '</div></details></li></ul>',
         );
     });
 
@@ -146,12 +158,16 @@ describe('Cut plugin', () => {
                     '{% endcut %}',
             ).replace(/(\r\n|\n|\r)/gm, ''),
         ).toBe(
-            '<ul><li><div class="yfm-cut"><div class="yfm-cut-title">Cut 1</div>' +
-                '<div class="yfm-cut-content"><p>Some text</p></div></div></li>' +
-                '<li><div class="yfm-cut"><div class="yfm-cut-title">Cut 2</div>' +
-                '<div class="yfm-cut-content"><p>Some text</p></div></div></li>' +
-                '<li><div class="yfm-cut"><div class="yfm-cut-title">Cut 3</div>' +
-                '<div class="yfm-cut-content"><p>Some text</p></div></div></li></ul>',
+            '<ul><li>' +
+                '<details class="yfm-cut">' +
+                '<summary class="yfm-cut-title">Cut 1</summary>' +
+                '<div class="yfm-cut-content"><p>Some text</p></div>' +
+                '</details></li>' +
+                '<li><details class="yfm-cut">' +
+                '<summary class="yfm-cut-title">Cut 2</summary><div class="yfm-cut-content">' +
+                '<p>Some text</p></div></details></li><li><details class="yfm-cut">' +
+                '<summary class="yfm-cut-title">Cut 3</summary>' +
+                '<div class="yfm-cut-content"><p>Some text</p></div></details></li></ul>',
         );
     });
 });


### PR DESCRIPTION
Task: https://github.com/orgs/diplodoc-platform/projects/2/views/1?pane=issue&itemId=55495840

Replace div tags to details and summary tags for cuts.

Before:

https://github.com/user-attachments/assets/4deda82f-2ef5-491c-992f-0ae3498e5919


After:

https://github.com/user-attachments/assets/6c7135aa-2fe0-41dd-b754-aac5e86af383

