### PR TITLE
feat(dist): export css and js without tabs and cuts

### DIFF
--- a/esbuild/build.mjs
+++ b/esbuild/build.mjs
@@ -74,24 +74,26 @@ const common = {
         }),
     ]);
 
-    await build({
-        ...common,
-        entryPoints: ['dist/css/yfm.css'],
-        outfile: 'dist/css/yfm.min.css',
-        minify: true,
-    });
-    await build({
-        ...common,
-        entryPoints: ['dist/css/base.css'],
-        outfile: 'dist/css/base.min.css',
-        minify: true,
-    });
-    await build({
-        ...common,
-        entryPoints: ['dist/css/_yfm-only.css'],
-        outfile: 'dist/css/_yfm-only.min.css',
-        minify: true,
-    });
+    await Promise.all([
+        build({
+            ...common,
+            entryPoints: ['dist/css/yfm.css'],
+            outfile: 'dist/css/yfm.min.css',
+            minify: true,
+        }),
+        build({
+            ...common,
+            entryPoints: ['dist/css/base.css'],
+            outfile: 'dist/css/base.min.css',
+            minify: true,
+        }),
+        build({
+            ...common,
+            entryPoints: ['dist/css/_yfm-only.css'],
+            outfile: 'dist/css/_yfm-only.min.css',
+            minify: true,
+        }),
+    ]);
 })();
 
 (async function buildJs() {

--- a/esbuild/build.mjs
+++ b/esbuild/build.mjs
@@ -54,7 +54,14 @@ const common = {
         build({
             ...common,
             entryPoints: ['src/scss/base.scss'],
-            outfile: 'dist/css/yfm-base.css',
+            outfile: 'dist/css/base.css',
+            format: 'iife',
+            plugins,
+        }),
+        build({
+            ...common,
+            entryPoints: ['src/scss/_yfm-only.scss'],
+            outfile: 'dist/css/_yfm-only.css',
             format: 'iife',
             plugins,
         }),
@@ -75,8 +82,14 @@ const common = {
     });
     await build({
         ...common,
-        entryPoints: ['dist/css/yfm-base.css'],
-        outfile: 'dist/css/yfm-base.min.css',
+        entryPoints: ['dist/css/base.css'],
+        outfile: 'dist/css/base.min.css',
+        minify: true,
+    });
+    await build({
+        ...common,
+        entryPoints: ['dist/css/_yfm-only.css'],
+        outfile: 'dist/css/_yfm-only.min.css',
         minify: true,
     });
 })();
@@ -91,7 +104,7 @@ const common = {
         build({
             ...common,
             entryPoints: ['src/js/base.ts'],
-            outfile: 'dist/js/yfm-base.js',
+            outfile: 'dist/js/base.js',
         }),
         build({
             ...common,
@@ -108,8 +121,8 @@ const common = {
     });
     await build({
         ...common,
-        entryPoints: ['dist/js/yfm-base.js'],
-        outfile: 'dist/js/yfm-base.min.js',
+        entryPoints: ['dist/js/base.js'],
+        outfile: 'dist/js/base.min.js',
         minify: true,
     });
 })();

--- a/esbuild/build.mjs
+++ b/esbuild/build.mjs
@@ -108,21 +108,34 @@ const common = {
         }),
         build({
             ...common,
+            entryPoints: ['src/js/_yfm-only.ts'],
+            outfile: 'dist/js/_yfm-only.js',
+        }),
+        build({
+            ...common,
             entryPoints: ['src/js/print/index.ts'],
             outfile: 'dist/js/print.js',
         }),
     ]);
 
-    await build({
-        ...common,
-        entryPoints: ['dist/js/yfm.js'],
-        outfile: 'dist/js/yfm.min.js',
-        minify: true,
-    });
-    await build({
-        ...common,
-        entryPoints: ['dist/js/base.js'],
-        outfile: 'dist/js/base.min.js',
-        minify: true,
-    });
+    await Promise.all([
+        build({
+            ...common,
+            entryPoints: ['dist/js/yfm.js'],
+            outfile: 'dist/js/yfm.min.js',
+            minify: true,
+        }),
+        build({
+            ...common,
+            entryPoints: ['dist/js/base.js'],
+            outfile: 'dist/js/base.min.js',
+            minify: true,
+        }),
+        build({
+            ...common,
+            entryPoints: ['dist/js/_yfm-only.js'],
+            outfile: 'dist/js/_yfm-only.min.js',
+            minify: true,
+        }),
+    ]);
 })();

--- a/esbuild/build.mjs
+++ b/esbuild/build.mjs
@@ -53,6 +53,13 @@ const common = {
         }),
         build({
             ...common,
+            entryPoints: ['src/scss/base.scss'],
+            outfile: 'dist/css/yfm-base.css',
+            format: 'iife',
+            plugins,
+        }),
+        build({
+            ...common,
             entryPoints: ['src/scss/print.scss'],
             outfile: 'dist/css/print.css',
             format: 'iife',
@@ -66,6 +73,12 @@ const common = {
         outfile: 'dist/css/yfm.min.css',
         minify: true,
     });
+    await build({
+        ...common,
+        entryPoints: ['dist/css/yfm-base.css'],
+        outfile: 'dist/css/yfm-base.min.css',
+        minify: true,
+    });
 })();
 
 (async function buildJs() {
@@ -74,6 +87,11 @@ const common = {
             ...common,
             entryPoints: ['src/js/index.ts'],
             outfile: 'dist/js/yfm.js',
+        }),
+        build({
+            ...common,
+            entryPoints: ['src/js/base.ts'],
+            outfile: 'dist/js/yfm-base.js',
         }),
         build({
             ...common,
@@ -86,6 +104,12 @@ const common = {
         ...common,
         entryPoints: ['dist/js/yfm.js'],
         outfile: 'dist/js/yfm.min.js',
+        minify: true,
+    });
+    await build({
+        ...common,
+        entryPoints: ['dist/js/yfm-base.js'],
+        outfile: 'dist/js/yfm-base.min.js',
         minify: true,
     });
 })();

--- a/src/js/_yfm-only.ts
+++ b/src/js/_yfm-only.ts
@@ -1,0 +1,1 @@
+import './term';

--- a/src/js/base.ts
+++ b/src/js/base.ts
@@ -1,0 +1,5 @@
+import './polyfill';
+import './code';
+import './term';
+import './wide-mode';
+import './patch';

--- a/src/js/base.ts
+++ b/src/js/base.ts
@@ -1,5 +1,2 @@
 import './polyfill';
 import './code';
-import './term';
-import './wide-mode';
-import './patch';

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -1,8 +1,4 @@
 import '@diplodoc/cut-extension/runtime';
 import '@diplodoc/tabs-extension/runtime';
 
-import './polyfill';
-import './code';
-import './term';
-import './wide-mode';
-import './patch';
+import './base';

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -2,3 +2,6 @@ import '@diplodoc/cut-extension/runtime';
 import '@diplodoc/tabs-extension/runtime';
 
 import './base';
+import './_yfm-only';
+import './wide-mode';
+import './patch';

--- a/src/scss/_yfm-only.scss
+++ b/src/scss/_yfm-only.scss
@@ -1,10 +1,12 @@
 /**
-  Note: This file excludes cut and tabs for flexibility,
-  as they may be handled separately in the future.
-  Direct usage is not recommended, as the file is subject
-  to changes without prior notice.
-*/
+    Note: This file excludes "cut" and "tabs" as they are handled separately
+    in dedicated extensions (packages). In the future, "note", "file", "term"
+    and "table" will also be excluded from this file and moved to yfm.scss,
+    once they are moved to separate packages. Direct usage is not recommended,
+    as the file is subject to changes without prior notice.
+ */
 
 @import 'note';
 @import 'file';
 @import 'table';
+@import 'term';

--- a/src/scss/_yfm-only.scss
+++ b/src/scss/_yfm-only.scss
@@ -1,0 +1,10 @@
+/**
+  Note: This file excludes cut and tabs for flexibility,
+  as they may be handled separately in the future.
+  Direct usage is not recommended, as the file is subject
+  to changes without prior notice.
+*/
+
+@import 'note';
+@import 'file';
+@import 'table';

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -1,0 +1,9 @@
+@import 'common';
+@import 'note';
+@import 'anchor';
+@import 'highlight';
+@import 'code';
+@import 'file';
+@import 'term';
+@import 'table';
+@import 'modal';

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -1,9 +1,6 @@
 @import 'common';
-@import 'note';
 @import 'anchor';
 @import 'highlight';
 @import 'code';
-@import 'file';
 @import 'term';
-@import 'table';
 @import 'modal';

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -2,5 +2,3 @@
 @import 'anchor';
 @import 'highlight';
 @import 'code';
-@import 'term';
-@import 'modal';

--- a/src/scss/yfm.scss
+++ b/src/scss/yfm.scss
@@ -1,4 +1,5 @@
 @import 'base';
 @import 'yfm-only';
+@import 'modal';
 @import '@diplodoc/cut-extension/runtime';
 @import '@diplodoc/tabs-extension/runtime';

--- a/src/scss/yfm.scss
+++ b/src/scss/yfm.scss
@@ -1,3 +1,4 @@
 @import 'base';
+@import 'yfm-only';
 @import '@diplodoc/cut-extension/runtime';
 @import '@diplodoc/tabs-extension/runtime';

--- a/src/scss/yfm.scss
+++ b/src/scss/yfm.scss
@@ -1,12 +1,3 @@
-@import 'common';
-@import 'note';
-@import 'anchor';
-@import 'highlight';
-@import 'code';
-@import 'file';
-@import 'term';
-@import 'table';
-@import 'modal';
-
+@import 'base';
 @import '@diplodoc/cut-extension/runtime';
 @import '@diplodoc/tabs-extension/runtime';


### PR DESCRIPTION
To connect cuts and tabs, the necessary styles have been separated for import. Additionally, provisions have been made to support the use of only basic styles in the future.

![2024-10-21_21-25-57](https://github.com/user-attachments/assets/1d9f999f-930d-4850-882c-bd4286468f0a)
