### PR TITLE
feat(imsize): rework image styling to get more control

### DIFF
--- a/src/transform/md.ts
+++ b/src/transform/md.ts
@@ -169,7 +169,7 @@ function initCompiler(md: MarkdownIt, options: OptionsType, env: EnvType) {
 
         // Sanitize the page
         return needToSanitizeHtml
-            ? sanitizeHtml(html, sanitizeOptions, env.forcedSanitizeCssWhiteList)
+            ? sanitizeHtml(html, sanitizeOptions, {cssWhiteList: env.additionalOptionsCssWhiteList})
             : html;
     };
 }

--- a/src/transform/md.ts
+++ b/src/transform/md.ts
@@ -168,7 +168,9 @@ function initCompiler(md: MarkdownIt, options: OptionsType, env: EnvType) {
         const html = md.renderer.render(tokens, md.options, env);
 
         // Sanitize the page
-        return needToSanitizeHtml ? sanitizeHtml(html, sanitizeOptions) : html;
+        return needToSanitizeHtml
+            ? sanitizeHtml(html, sanitizeOptions, env.forcedSanitizeCssWhiteList)
+            : html;
     };
 }
 

--- a/src/transform/plugins/imsize/const.ts
+++ b/src/transform/plugins/imsize/const.ts
@@ -4,4 +4,5 @@ export enum ImsizeAttr {
     Title = 'title',
     Width = 'width',
     Height = 'height',
+    Style = 'style',
 }

--- a/src/transform/plugins/imsize/index.ts
+++ b/src/transform/plugins/imsize/index.ts
@@ -1,6 +1,6 @@
-import {PluginSimple} from 'markdown-it';
+import {PluginWithOptions} from 'markdown-it';
 
-import {imageWithSize} from './plugin';
+import {ImsizeOptions, imageWithSize} from './plugin';
 
 /**
  * Imsize plugin for markdown-it.
@@ -8,8 +8,8 @@ import {imageWithSize} from './plugin';
  * Forked from https://github.com/tatsy/markdown-it-imsize
  */
 
-const imsize: PluginSimple = (md) => {
-    md.inline.ruler.before('emphasis', 'image', imageWithSize(md));
+const imsize: PluginWithOptions<ImsizeOptions> = (md, opts) => {
+    md.inline.ruler.before('emphasis', 'image', imageWithSize(md, opts));
 };
 
 export = imsize;

--- a/src/transform/plugins/imsize/plugin.ts
+++ b/src/transform/plugins/imsize/plugin.ts
@@ -6,7 +6,7 @@ import {ImsizeAttr} from './const';
 import {parseImageSize} from './helpers';
 
 export type ImsizeOptions = {
-    inlineSizeStyling?: boolean;
+    enableInlineStyling?: boolean;
 };
 
 export const imageWithSize = (md: MarkdownIt, opts?: ImsizeOptions): ParserInline.RuleInline => {
@@ -211,7 +211,7 @@ export const imageWithSize = (md: MarkdownIt, opts?: ImsizeOptions): ParserInlin
                 token.attrs.push([ImsizeAttr.Height, height]);
             }
 
-            if (opts?.inlineSizeStyling) {
+            if (opts?.enableInlineStyling) {
                 let style: string | undefined = '';
 
                 const widthWithPercent = width.includes('%');
@@ -225,8 +225,8 @@ export const imageWithSize = (md: MarkdownIt, opts?: ImsizeOptions): ParserInlin
                 if (height !== '') {
                     if (width !== '' && !heightWithPercent && !widthWithPercent) {
                         style += `aspect-ratio: ${width} / ${height};height: auto;`;
-                        state.env.forcedSanitizeCssWhiteList ??= {};
-                        state.env.forcedSanitizeCssWhiteList['aspect-ratio'] = true;
+                        state.env.additionalOptionsCssWhiteList ??= {};
+                        state.env.additionalOptionsCssWhiteList['aspect-ratio'] = true;
                     } else {
                         const heightString = heightWithPercent ? height : `${height}px`;
                         style += `height: ${heightString};`;

--- a/src/transform/plugins/imsize/plugin.ts
+++ b/src/transform/plugins/imsize/plugin.ts
@@ -207,21 +207,23 @@ export const imageWithSize = (md: MarkdownIt): ParserInline.RuleInline => {
                 token.attrs.push([ImsizeAttr.Height, height]);
             }
 
-            let style: string | undefined;
+            let style: string | undefined = '';
+
+            const widthWithPercent = width.includes('%');
+            const heightWithPercent = height.includes('%');
 
             if (width !== '') {
-                const widthWithPercent = width.includes('%');
-                const heightWithPercent = height.includes('%');
-
                 const widthString = widthWithPercent ? width : `${width}px`;
-                style = `width: ${widthString};`;
+                style += `width: ${widthString};`;
+            }
 
-                if (height !== '' && !heightWithPercent && !widthWithPercent) {
-                    style += ` aspect-ratio: ${width} / ${height}; height: auto;`;
+            if (height !== '') {
+                if (width !== '' && !heightWithPercent && !widthWithPercent) {
+                    style += `aspect-ratio: ${width} / ${height};height: auto;`;
+                } else {
+                    const heightString = heightWithPercent ? height : `${height}px`;
+                    style += `height: ${heightString};`;
                 }
-            } else if (height !== '') {
-                const heightString = height.includes('%') ? height : `${height}px`;
-                style = `height: ${heightString};`;
             }
 
             if (style) {

--- a/src/transform/plugins/imsize/plugin.ts
+++ b/src/transform/plugins/imsize/plugin.ts
@@ -5,7 +5,11 @@ import type Token from 'markdown-it/lib/token';
 import {ImsizeAttr} from './const';
 import {parseImageSize} from './helpers';
 
-export const imageWithSize = (md: MarkdownIt): ParserInline.RuleInline => {
+export type ImsizeOptions = {
+    inlineSizeStyling?: boolean;
+};
+
+export const imageWithSize = (md: MarkdownIt, opts?: ImsizeOptions): ParserInline.RuleInline => {
     // eslint-disable-next-line complexity
     return (state, silent) => {
         if (state.src.charCodeAt(state.pos) !== 0x21 /* ! */) {
@@ -207,27 +211,29 @@ export const imageWithSize = (md: MarkdownIt): ParserInline.RuleInline => {
                 token.attrs.push([ImsizeAttr.Height, height]);
             }
 
-            let style: string | undefined = '';
+            if (opts?.inlineSizeStyling) {
+                let style: string | undefined = '';
 
-            const widthWithPercent = width.includes('%');
-            const heightWithPercent = height.includes('%');
+                const widthWithPercent = width.includes('%');
+                const heightWithPercent = height.includes('%');
 
-            if (width !== '') {
-                const widthString = widthWithPercent ? width : `${width}px`;
-                style += `width: ${widthString};`;
-            }
-
-            if (height !== '') {
-                if (width !== '' && !heightWithPercent && !widthWithPercent) {
-                    style += `aspect-ratio: ${width} / ${height};height: auto;`;
-                } else {
-                    const heightString = heightWithPercent ? height : `${height}px`;
-                    style += `height: ${heightString};`;
+                if (width !== '') {
+                    const widthString = widthWithPercent ? width : `${width}px`;
+                    style += `width: ${widthString};`;
                 }
-            }
 
-            if (style) {
-                token.attrs.push([ImsizeAttr.Style, style]);
+                if (height !== '') {
+                    if (width !== '' && !heightWithPercent && !widthWithPercent) {
+                        style += `aspect-ratio: ${width} / ${height};height: auto;`;
+                    } else {
+                        const heightString = heightWithPercent ? height : `${height}px`;
+                        style += `height: ${heightString};`;
+                    }
+                }
+
+                if (style) {
+                    token.attrs.push([ImsizeAttr.Style, style]);
+                }
             }
         }
 

--- a/src/transform/plugins/imsize/plugin.ts
+++ b/src/transform/plugins/imsize/plugin.ts
@@ -225,6 +225,8 @@ export const imageWithSize = (md: MarkdownIt, opts?: ImsizeOptions): ParserInlin
                 if (height !== '') {
                     if (width !== '' && !heightWithPercent && !widthWithPercent) {
                         style += `aspect-ratio: ${width} / ${height};height: auto;`;
+                        state.env.forcedSanitizeCssWhiteList ??= {};
+                        state.env.forcedSanitizeCssWhiteList['aspect-ratio'] = true;
                     } else {
                         const heightString = heightWithPercent ? height : `${height}px`;
                         style += `height: ${heightString};`;

--- a/src/transform/plugins/imsize/plugin.ts
+++ b/src/transform/plugins/imsize/plugin.ts
@@ -206,6 +206,27 @@ export const imageWithSize = (md: MarkdownIt): ParserInline.RuleInline => {
             if (height !== '') {
                 token.attrs.push([ImsizeAttr.Height, height]);
             }
+
+            let style: string | undefined;
+
+            if (width !== '') {
+                const widthWithPercent = width.includes('%');
+                const heightWithPercent = height.includes('%');
+
+                const widthString = widthWithPercent ? width : `${width}px`;
+                style = `width: ${widthString};`;
+
+                if (height !== '' && !heightWithPercent && !widthWithPercent) {
+                    style += ` aspect-ratio: ${width} / ${height}; height: auto;`;
+                }
+            } else if (height !== '') {
+                const heightString = height.includes('%') ? height : `${height}px`;
+                style = `height: ${heightString};`;
+            }
+
+            if (style) {
+                token.attrs.push([ImsizeAttr.Style, style]);
+            }
         }
 
         state.pos = pos;

--- a/src/transform/sanitize.ts
+++ b/src/transform/sanitize.ts
@@ -601,14 +601,14 @@ function sanitizeStyles(html: string, options: SanitizeOptions) {
 export default function sanitize(
     html: string,
     options?: SanitizeOptions,
-    forcedSanitizeCssWhiteList?: CssWhiteList,
+    additionalOptions?: SanitizeOptions,
 ) {
     const sanitizeOptions = options || defaultOptions;
 
-    if (forcedSanitizeCssWhiteList) {
+    if (additionalOptions?.cssWhiteList) {
         sanitizeOptions.cssWhiteList = {
             ...sanitizeOptions.cssWhiteList,
-            ...forcedSanitizeCssWhiteList,
+            ...additionalOptions.cssWhiteList,
         };
     }
 

--- a/src/transform/sanitize.ts
+++ b/src/transform/sanitize.ts
@@ -4,6 +4,8 @@ import cssfilter from 'cssfilter';
 import * as cheerio from 'cheerio';
 import css from 'css';
 
+import {CssWhiteList} from './typings';
+
 const htmlTags = [
     'a',
     'abbr',
@@ -492,8 +494,6 @@ const allowedTags = Array.from(
 );
 const allowedAttributes = Array.from(new Set([...htmlAttrs, ...svgAttrs, ...yfmHtmlAttrs]));
 
-export type CssWhiteList = {[property: string]: boolean};
-
 export interface SanitizeOptions extends sanitizeHtml.IOptions {
     cssWhiteList?: CssWhiteList;
     disableStyleSanitizer?: boolean;
@@ -598,8 +598,19 @@ function sanitizeStyles(html: string, options: SanitizeOptions) {
     return styles + content;
 }
 
-export default function sanitize(html: string, options?: SanitizeOptions) {
+export default function sanitize(
+    html: string,
+    options?: SanitizeOptions,
+    forcedSanitizeCssWhiteList?: CssWhiteList,
+) {
     const sanitizeOptions = options || defaultOptions;
+
+    if (forcedSanitizeCssWhiteList) {
+        sanitizeOptions.cssWhiteList = {
+            ...sanitizeOptions.cssWhiteList,
+            ...forcedSanitizeCssWhiteList,
+        };
+    }
 
     const needToSanitizeStyles = !(sanitizeOptions.disableStyleSanitizer ?? false);
 

--- a/src/transform/typings.ts
+++ b/src/transform/typings.ts
@@ -74,6 +74,7 @@ export type EnvType<Extras extends {} = {}> = {
     assets?: unknown[];
     meta?: object;
     changelogs?: ChangelogItem[];
+    forcedSanitizeCssWhiteList?: CssWhiteList;
 } & Extras;
 
 export interface MarkdownItPluginOpts {
@@ -98,3 +99,5 @@ export type MarkdownItPluginCb<T extends {} = {}> = {
 export type MarkdownItPreprocessorCb<T extends unknown = {}> = {
     (input: string, opts: T & Partial<MarkdownItPluginOpts>, md?: MarkdownIt): string;
 };
+
+export type CssWhiteList = {[property: string]: boolean};

--- a/src/transform/typings.ts
+++ b/src/transform/typings.ts
@@ -74,7 +74,7 @@ export type EnvType<Extras extends {} = {}> = {
     assets?: unknown[];
     meta?: object;
     changelogs?: ChangelogItem[];
-    forcedSanitizeCssWhiteList?: CssWhiteList;
+    additionalOptionsCssWhiteList?: CssWhiteList;
 } & Extras;
 
 export interface MarkdownItPluginOpts {

--- a/test/data/imsize/imsize-fixtures.txt
+++ b/test/data/imsize/imsize-fixtures.txt
@@ -226,7 +226,7 @@ Coverage. Image
 .
 ![test]( x =100x200)
 .
-<p><img src="x" alt="test" width="100" height="200"></p>
+<p><img src="x" alt="test" width="100" height="200" style="width: 100px; aspect-ratio: 100 / 200; height: auto;"></p>
 .
 .
 ![test]( x =x)
@@ -236,17 +236,17 @@ Coverage. Image
 .
 ![test]( x =100x)
 .
-<p><img src="x" alt="test" width="100"></p>
+<p><img src="x" alt="test" width="100" style="width: 100px;"></p>
 .
 .
 ![test]( x =x200)
 .
-<p><img src="x" alt="test" height="200"></p>
+<p><img src="x" alt="test" height="200" style="height: 200px;"></p>
 .
 .
 ![test]( x "title" =100x200)
 .
-<p><img src="x" alt="test" title="title" width="100" height="200"></p>
+<p><img src="x" alt="test" title="title" width="100" height="200" style="width: 100px; aspect-ratio: 100 / 200; height: auto;"></p>
 .
 .
 ![test]( x =WxH )
@@ -266,7 +266,7 @@ Coverage. Image
 .
 ![test](http://this.is.test.jpg =100x200)
 .
-<p><img src="http://this.is.test.jpg" alt="test" width="100" height="200"></p>
+<p><img src="http://this.is.test.jpg" alt="test" width="100" height="200" style="width: 100px; aspect-ratio: 100 / 200; height: auto;"></p>
 .
 .
 ![test](<x =100x200)
@@ -276,12 +276,12 @@ Coverage. Image
 .
 ![test](<x> =100x200)
 .
-<p><img src="x" alt="test" width="100" height="200"></p>
+<p><img src="x" alt="test" width="100" height="200" style="width: 100px; aspect-ratio: 100 / 200; height: auto;"></p>
 .
 .
 ![test](test =100%x)
 .
-<p><img src="test" alt="test" width="100%"></p>
+<p><img src="test" alt="test" width="100%" style="width: 100%;"></p>
 .
 
 Coverage. Link

--- a/test/data/imsize/imsize-fixtures.txt
+++ b/test/data/imsize/imsize-fixtures.txt
@@ -226,7 +226,7 @@ Coverage. Image
 .
 ![test]( x =100x200)
 .
-<p><img src="x" alt="test" width="100" height="200" style="width: 100px; aspect-ratio: 100 / 200; height: auto;"></p>
+<p><img src="x" alt="test" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
 .
 .
 ![test]( x =x)
@@ -246,7 +246,7 @@ Coverage. Image
 .
 ![test]( x "title" =100x200)
 .
-<p><img src="x" alt="test" title="title" width="100" height="200" style="width: 100px; aspect-ratio: 100 / 200; height: auto;"></p>
+<p><img src="x" alt="test" title="title" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
 .
 .
 ![test]( x =WxH )
@@ -266,7 +266,7 @@ Coverage. Image
 .
 ![test](http://this.is.test.jpg =100x200)
 .
-<p><img src="http://this.is.test.jpg" alt="test" width="100" height="200" style="width: 100px; aspect-ratio: 100 / 200; height: auto;"></p>
+<p><img src="http://this.is.test.jpg" alt="test" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
 .
 .
 ![test](<x =100x200)
@@ -276,12 +276,32 @@ Coverage. Image
 .
 ![test](<x> =100x200)
 .
-<p><img src="x" alt="test" width="100" height="200" style="width: 100px; aspect-ratio: 100 / 200; height: auto;"></p>
+<p><img src="x" alt="test" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
 .
 .
 ![test](test =100%x)
 .
 <p><img src="test" alt="test" width="100%" style="width: 100%;"></p>
+.
+.
+![test](test =x100%)
+.
+<p><img src="test" alt="test" height="100%" style="height: 100%;"></p>
+.
+.
+![test](test =100%x100%)
+.
+<p><img src="test" alt="test" width="100%" height="100%" style="width: 100%;height: 100%;"></p>
+.
+.
+![test](test =100%x200)
+.
+<p><img src="test" alt="test" width="100%" height="200" style="width: 100%;height: 200px;"></p>
+.
+.
+![test](test =100x100%)
+.
+<p><img src="test" alt="test" width="100" height="100%" style="width: 100px;height: 100%;"></p>
 .
 
 Coverage. Link

--- a/test/data/imsize/imsize-fixtures.txt
+++ b/test/data/imsize/imsize-fixtures.txt
@@ -226,7 +226,7 @@ Coverage. Image
 .
 ![test]( x =100x200)
 .
-<p><img src="x" alt="test" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
+<p><img src="x" alt="test" width="100" height="200"></p>
 .
 .
 ![test]( x =x)
@@ -236,17 +236,17 @@ Coverage. Image
 .
 ![test]( x =100x)
 .
-<p><img src="x" alt="test" width="100" style="width: 100px;"></p>
+<p><img src="x" alt="test" width="100"></p>
 .
 .
 ![test]( x =x200)
 .
-<p><img src="x" alt="test" height="200" style="height: 200px;"></p>
+<p><img src="x" alt="test" height="200"></p>
 .
 .
 ![test]( x "title" =100x200)
 .
-<p><img src="x" alt="test" title="title" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
+<p><img src="x" alt="test" title="title" width="100" height="200"></p>
 .
 .
 ![test]( x =WxH )
@@ -266,7 +266,7 @@ Coverage. Image
 .
 ![test](http://this.is.test.jpg =100x200)
 .
-<p><img src="http://this.is.test.jpg" alt="test" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
+<p><img src="http://this.is.test.jpg" alt="test" width="100" height="200"></p>
 .
 .
 ![test](<x =100x200)
@@ -276,32 +276,32 @@ Coverage. Image
 .
 ![test](<x> =100x200)
 .
-<p><img src="x" alt="test" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
+<p><img src="x" alt="test" width="100" height="200"></p>
 .
 .
 ![test](test =100%x)
 .
-<p><img src="test" alt="test" width="100%" style="width: 100%;"></p>
+<p><img src="test" alt="test" width="100%"></p>
 .
 .
 ![test](test =x100%)
 .
-<p><img src="test" alt="test" height="100%" style="height: 100%;"></p>
+<p><img src="test" alt="test" height="100%"></p>
 .
 .
 ![test](test =100%x100%)
 .
-<p><img src="test" alt="test" width="100%" height="100%" style="width: 100%;height: 100%;"></p>
+<p><img src="test" alt="test" width="100%" height="100%"></p>
 .
 .
 ![test](test =100%x200)
 .
-<p><img src="test" alt="test" width="100%" height="200" style="width: 100%;height: 200px;"></p>
+<p><img src="test" alt="test" width="100%" height="200"></p>
 .
 .
 ![test](test =100x100%)
 .
-<p><img src="test" alt="test" width="100" height="100%" style="width: 100px;height: 100%;"></p>
+<p><img src="test" alt="test" width="100" height="100%"></p>
 .
 
 Coverage. Link

--- a/test/data/imsize/imsize-inlineSizeStyling-fixtures.txt
+++ b/test/data/imsize/imsize-inlineSizeStyling-fixtures.txt
@@ -1,0 +1,81 @@
+Coverage. Image with inlineStyling
+.
+![test]( x =100x200)
+.
+<p><img src="x" alt="test" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
+.
+.
+![test]( x =x)
+.
+<p><img src="x" alt="test"></p>
+.
+.
+![test]( x =100x)
+.
+<p><img src="x" alt="test" width="100" style="width: 100px;"></p>
+.
+.
+![test]( x =x200)
+.
+<p><img src="x" alt="test" height="200" style="height: 200px;"></p>
+.
+.
+![test]( x "title" =100x200)
+.
+<p><img src="x" alt="test" title="title" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
+.
+.
+![test]( x =WxH )
+.
+<p>![test]( x =WxH )</p>
+.
+.
+![test]( x = 100x200 )
+.
+<p>![test]( x = 100x200 )</p>
+.
+.
+![test]( x =aaaxbbb )
+.
+<p>![test]( x =aaaxbbb )</p>
+.
+.
+![test](http://this.is.test.jpg =100x200)
+.
+<p><img src="http://this.is.test.jpg" alt="test" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
+.
+.
+![test](<x =100x200)
+.
+<p>![test](&lt;x =100x200)</p>
+.
+.
+![test](<x> =100x200)
+.
+<p><img src="x" alt="test" width="100" height="200" style="width: 100px;aspect-ratio: 100 / 200;height: auto;"></p>
+.
+.
+![test](test =100%x)
+.
+<p><img src="test" alt="test" width="100%" style="width: 100%;"></p>
+.
+.
+![test](test =x100%)
+.
+<p><img src="test" alt="test" height="100%" style="height: 100%;"></p>
+.
+.
+![test](test =100%x100%)
+.
+<p><img src="test" alt="test" width="100%" height="100%" style="width: 100%;height: 100%;"></p>
+.
+.
+![test](test =100%x200)
+.
+<p><img src="test" alt="test" width="100%" height="200" style="width: 100%;height: 200px;"></p>
+.
+.
+![test](test =100x100%)
+.
+<p><img src="test" alt="test" width="100" height="100%" style="width: 100px;height: 100%;"></p>
+.

--- a/test/imsize.test.ts
+++ b/test/imsize.test.ts
@@ -14,3 +14,13 @@ describe('imsize', () => {
 
     generate(path.join(__dirname, 'data/imsize/imsize-fixtures.txt'), md);
 });
+
+describe('imsize with inlineStyling', () => {
+    const md = new MarkdownIt({
+        html: true,
+        linkify: false,
+        typographer: false,
+    }).use(imsize, {inlineSizeStyling: true});
+
+    generate(path.join(__dirname, 'data/imsize/imsize-inlineSizeStyling-fixtures.txt'), md);
+});

--- a/test/imsize.test.ts
+++ b/test/imsize.test.ts
@@ -20,7 +20,7 @@ describe('imsize with inlineStyling', () => {
         html: true,
         linkify: false,
         typographer: false,
-    }).use(imsize, {inlineSizeStyling: true});
+    }).use(imsize, {enableInlineStyling: true});
 
     generate(path.join(__dirname, 'data/imsize/imsize-inlineSizeStyling-fixtures.txt'), md);
 });


### PR DESCRIPTION
These changes are necessary in order to gain more control over the appearance of the images in cases where we need to maintain the proportions when resizing the container.
Now this is a bit bugged - when the height exceeds the expected one, we see empty space around the image from above and below