### PR TITLE
fix(code): Add ability to disable SEO optimization for titles

### DIFF
--- a/src/transform/plugins/anchors/index.ts
+++ b/src/transform/plugins/anchors/index.ts
@@ -76,20 +76,14 @@ const removeCustomIds = (token: Token) => {
 interface Options {
     extractTitle?: boolean;
     supportGithubAnchors?: boolean;
-    disableHeadingsHiddenContent?: boolean;
+    disableCommonAnchors?: boolean;
     transformLink: (v: string) => string;
     getPublicPath?: (options: Options, v?: string) => string;
 }
 
 const index: MarkdownItPluginCb<Options> = (md, options) => {
-    const {
-        extractTitle,
-        path,
-        log,
-        supportGithubAnchors,
-        getPublicPath,
-        disableHeadingsHiddenContent,
-    } = options;
+    const {extractTitle, path, log, supportGithubAnchors, getPublicPath, disableCommonAnchors} =
+        options;
 
     const plugin = (state: StateCore) => {
         /* Do not use the plugin if it is included in the file */
@@ -151,7 +145,7 @@ const index: MarkdownItPluginCb<Options> = (md, options) => {
                 const anchorTitle = removeCustomId(title).replace(/`/g, '');
                 allAnchorIds.forEach((customId) => {
                     const setId = id !== customId;
-                    if (!disableHeadingsHiddenContent) {
+                    if (!disableCommonAnchors) {
                         const linkTokens = createLinkTokens(
                             state,
                             customId,

--- a/src/transform/plugins/anchors/index.ts
+++ b/src/transform/plugins/anchors/index.ts
@@ -76,14 +76,20 @@ const removeCustomIds = (token: Token) => {
 interface Options {
     extractTitle?: boolean;
     supportGithubAnchors?: boolean;
-    disableSEOFixForTitles?: boolean;
+    disableHeadingsHiddenContent?: boolean;
     transformLink: (v: string) => string;
     getPublicPath?: (options: Options, v?: string) => string;
 }
 
 const index: MarkdownItPluginCb<Options> = (md, options) => {
-    const {extractTitle, path, log, supportGithubAnchors, getPublicPath, disableSEOFixForTitles} =
-        options;
+    const {
+        extractTitle,
+        path,
+        log,
+        supportGithubAnchors,
+        getPublicPath,
+        disableHeadingsHiddenContent,
+    } = options;
 
     const plugin = (state: StateCore) => {
         /* Do not use the plugin if it is included in the file */
@@ -145,7 +151,7 @@ const index: MarkdownItPluginCb<Options> = (md, options) => {
                 const anchorTitle = removeCustomId(title).replace(/`/g, '');
                 allAnchorIds.forEach((customId) => {
                     const setId = id !== customId;
-                    if (!disableSEOFixForTitles) {
+                    if (!disableHeadingsHiddenContent) {
                         const linkTokens = createLinkTokens(
                             state,
                             customId,

--- a/src/transform/plugins/anchors/index.ts
+++ b/src/transform/plugins/anchors/index.ts
@@ -76,12 +76,14 @@ const removeCustomIds = (token: Token) => {
 interface Options {
     extractTitle?: boolean;
     supportGithubAnchors?: boolean;
+    disableSEOFixForTitles?: boolean;
     transformLink: (v: string) => string;
     getPublicPath?: (options: Options, v?: string) => string;
 }
 
 const index: MarkdownItPluginCb<Options> = (md, options) => {
-    const {extractTitle, path, log, supportGithubAnchors, getPublicPath} = options;
+    const {extractTitle, path, log, supportGithubAnchors, getPublicPath, disableSEOFixForTitles} =
+        options;
 
     const plugin = (state: StateCore) => {
         /* Do not use the plugin if it is included in the file */
@@ -143,9 +145,16 @@ const index: MarkdownItPluginCb<Options> = (md, options) => {
                 const anchorTitle = removeCustomId(title).replace(/`/g, '');
                 allAnchorIds.forEach((customId) => {
                     const setId = id !== customId;
-                    const linkTokens = createLinkTokens(state, customId, anchorTitle, setId, href);
-
-                    inlineToken.children?.unshift(...linkTokens);
+                    if (!disableSEOFixForTitles) {
+                        const linkTokens = createLinkTokens(
+                            state,
+                            customId,
+                            anchorTitle,
+                            setId,
+                            href,
+                        );
+                        inlineToken.children?.unshift(...linkTokens);
+                    }
 
                     if (supportGithubAnchors) {
                         const ghLinkTokens = createLinkTokens(state, ghId, anchorTitle, true, href);

--- a/test/anchors.test.ts
+++ b/test/anchors.test.ts
@@ -144,4 +144,34 @@ describe('Anchors', () => {
             expect(result[1]).toBe('Test');
         });
     });
+
+    describe('with disableSEOFixForTitles', () => {
+        it('should not add anchor links when disableSEOFixForTitles is true', () => {
+            const {
+                result: {html},
+            } = transform('## Test heading', {
+                plugins: [includes, anchors],
+                path: mocksPath,
+                root: dirname(mocksPath),
+                getPublicPath,
+                disableSEOFixForTitles: true,
+            });
+
+            expect(html).toEqual('<h2 id="test-heading">Test heading</h2>\n');
+        });
+
+        it('should not add anchor links for custom anchors when disableSEOFixForTitles is true', () => {
+            const {
+                result: {html},
+            } = transform('## Test heading {#custom-id}', {
+                plugins: [includes, anchors],
+                path: mocksPath,
+                root: dirname(mocksPath),
+                getPublicPath,
+                disableSEOFixForTitles: true,
+            });
+
+            expect(html).toEqual('<h2 id="custom-id">Test heading</h2>\n');
+        });
+    });
 });

--- a/test/anchors.test.ts
+++ b/test/anchors.test.ts
@@ -145,8 +145,8 @@ describe('Anchors', () => {
         });
     });
 
-    describe('with disableHeadingsHiddenContent', () => {
-        it('should not add anchor links when disableHeadingsHiddenContent is true', () => {
+    describe('with disableCommonAnchors', () => {
+        it('should not add anchor links when disableCommonAnchors is true', () => {
             const {
                 result: {html},
             } = transform('## Test heading', {
@@ -154,13 +154,13 @@ describe('Anchors', () => {
                 path: mocksPath,
                 root: dirname(mocksPath),
                 getPublicPath,
-                disableHeadingsHiddenContent: true,
+                disableCommonAnchors: true,
             });
 
             expect(html).toEqual('<h2 id="test-heading">Test heading</h2>\n');
         });
 
-        it('should not add anchor links for custom anchors when disableHeadingsHiddenContent is true', () => {
+        it('should not add anchor links for custom anchors when disableCommonAnchors is true', () => {
             const {
                 result: {html},
             } = transform('## Test heading {#custom-id}', {
@@ -168,7 +168,7 @@ describe('Anchors', () => {
                 path: mocksPath,
                 root: dirname(mocksPath),
                 getPublicPath,
-                disableHeadingsHiddenContent: true,
+                disableCommonAnchors: true,
             });
 
             expect(html).toEqual('<h2 id="custom-id">Test heading</h2>\n');

--- a/test/anchors.test.ts
+++ b/test/anchors.test.ts
@@ -145,8 +145,8 @@ describe('Anchors', () => {
         });
     });
 
-    describe('with disableSEOFixForTitles', () => {
-        it('should not add anchor links when disableSEOFixForTitles is true', () => {
+    describe('with disableHeadingsHiddenContent', () => {
+        it('should not add anchor links when disableHeadingsHiddenContent is true', () => {
             const {
                 result: {html},
             } = transform('## Test heading', {
@@ -154,13 +154,13 @@ describe('Anchors', () => {
                 path: mocksPath,
                 root: dirname(mocksPath),
                 getPublicPath,
-                disableSEOFixForTitles: true,
+                disableHeadingsHiddenContent: true,
             });
 
             expect(html).toEqual('<h2 id="test-heading">Test heading</h2>\n');
         });
 
-        it('should not add anchor links for custom anchors when disableSEOFixForTitles is true', () => {
+        it('should not add anchor links for custom anchors when disableHeadingsHiddenContent is true', () => {
             const {
                 result: {html},
             } = transform('## Test heading {#custom-id}', {
@@ -168,7 +168,7 @@ describe('Anchors', () => {
                 path: mocksPath,
                 root: dirname(mocksPath),
                 getPublicPath,
-                disableSEOFixForTitles: true,
+                disableHeadingsHiddenContent: true,
             });
 
             expect(html).toEqual('<h2 id="custom-id">Test heading</h2>\n');


### PR DESCRIPTION
In out service we use YFM for email content. To be exact we compile YFM to HTML and then send it to email. The problem is that we don't inline or send CSS with email so hiddenDesc for title is visible to user and user sees 2 titles.

This PR allowed us to disable this SEO optimisation with `disableSEOFixForTitles` option.

disableSEOFixForTitles: false (default)
```
html: '<h2 id="test1" data-line="2" class="line"><a href="#test1" class="yfm-anchor" aria-hidden="true" target="_blank" rel="noreferrer noopener"><span class="visually-hidden" data-no-index="true">test1</span></a>test1</h2>\n',
```

disableSEOFixForTitles: true
```
html: '<h2 id="test1" data-line="2" class="line">test1</h2>\n',
```