### PR TITLE
feat(anchors): remove unsupported chars from heading ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "markdownlint": "^0.32.1",
         "markdownlint-rule-helpers": "0.17.2",
         "sanitize-html": "^2.11.0",
-        "slugify": "1.6.5",
+        "slugify": "1.6.6",
         "svgo": "^3.2.0"
       },
       "devDependencies": {
@@ -13094,8 +13094,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.5",
-      "license": "MIT",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
       "engines": {
         "node": ">=8.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "markdownlint": "^0.32.1",
     "markdownlint-rule-helpers": "0.17.2",
     "sanitize-html": "^2.11.0",
-    "slugify": "1.6.5",
+    "slugify": "1.6.6",
     "svgo": "^3.2.0"
   },
   "devDependencies": {

--- a/src/transform/plugins/anchors/index.ts
+++ b/src/transform/plugins/anchors/index.ts
@@ -3,13 +3,12 @@ import GithubSlugger from 'github-slugger';
 import StateCore from 'markdown-it/lib/rules_core/state_core';
 import Token from 'markdown-it/lib/token';
 import {escapeHtml} from 'markdown-it/lib/common/utils';
+import slugify from 'slugify';
 
 import {headingInfo} from '../../utils';
 import {MarkdownItPluginCb} from '../typings';
 
 import {CUSTOM_ID_EXCEPTION, CUSTOM_ID_REGEXP} from './constants';
-
-const slugify: (str: string, opts: {}) => string = require('slugify');
 
 function createLinkTokens(
     state: StateCore,
@@ -127,7 +126,7 @@ const index: MarkdownItPluginCb<Options> = (md, options) => {
                 } else {
                     id = slugify(title, {
                         lower: true,
-                        remove: /[*+~.()'"!:@`ь?]/g,
+                        remove: /[^\w\s$_\-,;=/]+/g,
                     });
                     ghId = slugger.slug(title);
                 }

--- a/test/__snapshots__/anchors.test.ts.snap
+++ b/test/__snapshots__/anchors.test.ts.snap
@@ -254,8 +254,8 @@ exports[`Anchors should include content by anchor in sharped path file 1`] = `
 `;
 
 exports[`Anchors should remove quotes from id 1`] = `
-<h2 id="«heading»-with-quotes">
-  <a href="link.html#«heading»-with-quotes"
+<h2 id="heading-with-quotes">
+  <a href="link.html#heading-with-quotes"
      class="yfm-anchor"
      aria-hidden="true"
   >

--- a/test/__snapshots__/anchors.test.ts.snap
+++ b/test/__snapshots__/anchors.test.ts.snap
@@ -29,6 +29,25 @@ exports[`Anchors should add anchor with auto naming, using entire heading text 1
 </p>
 `;
 
+exports[`Anchors should add id for heading with allowed chars in fragment (RFC 3986)  1`] = `
+<h2 id="a-c5percentdollarandabc_;xx,=3/bbb">
+  <a href="link.html#a-c5percentdollarandabc_;xx,=3/bbb"
+     class="yfm-anchor"
+     aria-hidden="true"
+  >
+    <span class="visually-hidden"
+          data-no-index="true"
+    >
+      A-c~5%!$&amp;(abc)*_+;xx,@=3/':b?b.b'
+    </span>
+  </a>
+  A-c~5%!$&amp;(abc)*_+;xx,@=3/':b?b.b'
+</h2>
+<p>
+  Content
+</p>
+`;
+
 exports[`Anchors should add multiple anchors 1`] = `
 <pre>
   <code>
@@ -231,6 +250,25 @@ exports[`Anchors should include content by anchor in sharped path file 1`] = `
 </p>
 <p>
   After include
+</p>
+`;
+
+exports[`Anchors should remove quotes from id 1`] = `
+<h2 id="«heading»-with-quotes">
+  <a href="link.html#«heading»-with-quotes"
+     class="yfm-anchor"
+     aria-hidden="true"
+  >
+    <span class="visually-hidden"
+          data-no-index="true"
+    >
+      «Heading» “with” "quotes'
+    </span>
+  </a>
+  «Heading» “with” "quotes'
+</h2>
+<p>
+  Content
 </p>
 `;
 

--- a/test/anchors.test.ts
+++ b/test/anchors.test.ts
@@ -121,6 +121,28 @@ describe('Anchors', () => {
         ).toMatchSnapshot();
     });
 
+    it('should add id for heading with allowed chars in fragment (RFC 3986) ', () => {
+        expect(
+            // heading contains all allowed chars in fragment (hash) in accordance with RFC 3986
+            html(dedent`
+                ## A-c~5%!$&(abc)*_+;xx,@=3/':b?b.b'
+
+                Content
+                `),
+        ).toMatchSnapshot();
+    });
+
+    it('should remove quotes from id', () => {
+        expect(
+            // heading contains all allowed chars in fragment (hash) in accordance with RFC 3986
+            html(dedent`
+                ## «Heading» “with” "quotes'
+
+                Content
+                `),
+        ).toMatchSnapshot();
+    });
+
     describe('with extract title', () => {
         const transformWithTitle = (text: string) => {
             const {


### PR DESCRIPTION
Passed a stricter regexp to slugify, thats remove all unsupported symbols from ids

Read more about the supported symbols here: https://datatracker.ietf.org/doc/html/rfc3986#section-3.5