### PR TITLE
feat: Add image captions support

### DIFF
--- a/src/transform/plugins/images/collect.ts
+++ b/src/transform/plugins/images/collect.ts
@@ -27,7 +27,7 @@ const collect = (input: string, options: Options) => {
         const children = token.children || [];
 
         children.forEach((childToken) => {
-            if (childToken.type !== 'image') {
+            if (childToken.type !== 'image' && childToken.type !== 'image_with_caption') {
                 return;
             }
 
@@ -43,7 +43,7 @@ const collect = (input: string, options: Options) => {
             if (singlePage && !path.includes('_includes/')) {
                 const newSrc = relative(root, resolveRelativePath(path, src));
 
-                result = result.replace(src, newSrc);
+                result = result.replace(new RegExp(src, 'g'), newSrc);
             }
 
             copyFile(targetPath, targetDestPath);

--- a/src/transform/plugins/images/collect.ts
+++ b/src/transform/plugins/images/collect.ts
@@ -27,7 +27,7 @@ const collect = (input: string, options: Options) => {
         const children = token.children || [];
 
         children.forEach((childToken) => {
-            if (childToken.type !== 'image' && childToken.type !== 'image_with_caption') {
+            if (childToken.type !== 'image') {
                 return;
             }
 

--- a/src/transform/plugins/images/index.ts
+++ b/src/transform/plugins/images/index.ts
@@ -200,11 +200,6 @@ const index: MarkdownItPluginCb<Opts> = (md, opts) => {
 
         return token.attrGet('content') || '';
     };
-
-    md.renderer.rules.figure_open = () => '<figure>';
-    md.renderer.rules.figure_close = () => '</figure>';
-    md.renderer.rules.figcaption_open = () => '<figcaption>';
-    md.renderer.rules.figcaption_close = () => '</figcaption>';
 };
 
 export = index;


### PR DESCRIPTION
# Add support for image captions using `figcaption` tag

## Description
Added support for image captions using HTML's semantic `figure` and `figcaption` tags. 
This enhances image context and improves document accessibility by providing visual relationships between images and their captions.

## Features
- New caption syntax with two options:
  1. Use the title as caption: `![Alt text](image.jpg "Caption text" =100x100){ caption }`
  2. Explicit caption: `![Alt text](image.jpg "Title" =100x100){ caption="Custom caption text" }`
- Outputs semantic HTML using `<figure>` and `<figcaption>` tags
- Maintains compatibility with existing image features (eg. SVG inlining)

## Example
Input:
```markdown
![Alt text](image.jpg "Default caption text" =100x100){ caption }
![Alt text](image.jpg "Title" =100x100){ caption="Specified caption text" }
```

Output:
```html
<figure>
    <img src="image.jpg" alt="Alt text" title="Default caption text" width="100" height="100">
    <figcaption>Default caption text</figcaption>
</figure>

<figure>
    <img src="image.jpg" alt="Alt text" title="Title" width="100" height="100">
    <figcaption>Specified caption text</figcaption>
</figure>
```

## Documentation
Corresponding documentation PR: https://github.com/diplodoc-platform/docs/pull/80

## Technical Changes
- Added new markdown-it inline rule for parsing caption syntax
- Implemented token transformation for figure/figcaption wrapping
- Fixed image path replacement to handle multiple occurrences
- Improved loop handling for patched images

## Testing
- Manual testing with various image caption configurations
- Verified compatibility with existing image features
- Tested multiple images in a single document

Closes DOCSTOOLS-3428

Related issue: #514 
