### PR TITLE
fix: move ts-dedent to normal deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "markdownlint-rule-helpers": "0.17.2",
         "sanitize-html": "^2.11.0",
         "slugify": "1.6.6",
-        "svgo": "^3.2.0"
+        "svgo": "^3.2.0",
+        "ts-dedent": "^2.2.0"
       },
       "devDependencies": {
         "@diplodoc/babel-preset": "^1.0.2",
@@ -53,7 +54,6 @@
         "markdown-it-testgen": "^0.1.6",
         "postcss": "^8.4.27",
         "postcss-preset-env": "^9.1.1",
-        "ts-dedent": "^2.2.0",
         "ts-jest": "28.0.8",
         "typescript": "4.7.4"
       },
@@ -13985,8 +13985,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.10"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "markdownlint-rule-helpers": "0.17.2",
     "sanitize-html": "^2.11.0",
     "slugify": "1.6.6",
-    "svgo": "^3.2.0"
+    "svgo": "^3.2.0",
+    "ts-dedent": "^2.2.0"
   },
   "devDependencies": {
     "@diplodoc/babel-preset": "^1.0.2",
@@ -85,7 +86,6 @@
     "markdown-it-testgen": "^0.1.6",
     "postcss": "^8.4.27",
     "postcss-preset-env": "^9.1.1",
-    "ts-dedent": "^2.2.0",
     "ts-jest": "28.0.8",
     "typescript": "4.7.4"
   },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request, before submitting, please read commit message formatting guidelines at https://www.conventionalcommits.org/en/v1.0.0/

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that the code is up-to-date with the `master` branch.
4. Include a description of the proposed changes and how to test them.

For Russian speaking contributors:
Перед отправкой PR-a, пожалуйста, прочтите гайды для разработчиков платформы Diplodoc : https://diplodoc.com/docs/ru/dev/
#xxxx" -->

## Description

<!-- Please include a summary of the changes. If it is feasible, it is worth attaching a screenshot or video of the changes. -->
- moves ts-dedent to normal dependencies from dev dependencies since it's used in the actual package code
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
