### PR TITLE
fix: incorrect focus setting when opening multiple terms sequentially

### DIFF
--- a/src/js/term/utils.ts
+++ b/src/js/term/utils.ts
@@ -173,7 +173,7 @@ export function openDefinition(target: HTMLElement) {
 
     definitionElement.classList.toggle(openClass);
 
-    trapFocus(definitionElement);
+    trapFocus(definitionElement, target);
 }
 
 export function closeDefinition(definition: HTMLElement) {
@@ -210,12 +210,18 @@ function getCoords(elem: HTMLElement) {
     return {top: Math.round(top), left: Math.round(left)};
 }
 
-export function trapFocus(element: HTMLElement) {
+export function trapFocus(element: HTMLElement, termButton: HTMLElement) {
     const focusableElements = element.querySelectorAll(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
     );
     const firstFocusableElement = focusableElements[0] as HTMLElement;
     const lastFocusableElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+    // if another term was previously closed, the focus may still be on it
+    if (!firstFocusableElement && document.activeElement !== termButton) {
+        termButton.focus();
+        return;
+    }
 
     if (firstFocusableElement) {
         firstFocusableElement.focus();


### PR DESCRIPTION
Bug case: when opening several terms sequentially, if there are no interactive elements in their contents, the focus remains on the open button of the previous term.

https://github.com/user-attachments/assets/bfa1af7c-d450-493e-bb43-d19df5858500

Fix: if there are no interactive elements in the content, I add a check to see if the focus is set on the current term button. if not, then I rearrange the focus.