### PR TITLE
fix: force focus on closing term prevents switching to other elements on a click

### DIFF
--- a/src/js/term/index.ts
+++ b/src/js/term/index.ts
@@ -25,7 +25,7 @@ if (typeof document !== 'undefined') {
         }
 
         if (event.key === 'Escape' && openedDefinition) {
-            closeDefinition(openedDefinition);
+            closeDefinition(openedDefinition, true);
         }
     });
 

--- a/src/js/term/index.ts
+++ b/src/js/term/index.ts
@@ -2,6 +2,7 @@ import {getEventTarget, isCustom} from '../utils';
 
 import {
     closeDefinition,
+    getTermByDefinition,
     openClass,
     openDefinition,
     openDefinitionClass,
@@ -25,7 +26,8 @@ if (typeof document !== 'undefined') {
         }
 
         if (event.key === 'Escape' && openedDefinition) {
-            closeDefinition(openedDefinition, true);
+            closeDefinition(openedDefinition);
+            getTermByDefinition(openedDefinition)?.focus(); // Set focus back to open button after closing popup
         }
     });
 

--- a/src/js/term/utils.ts
+++ b/src/js/term/utils.ts
@@ -173,10 +173,10 @@ export function openDefinition(target: HTMLElement) {
 
     definitionElement.classList.toggle(openClass);
 
-    trapFocus(definitionElement, target);
+    trapFocus(definitionElement);
 }
 
-export function closeDefinition(definition: HTMLElement, focus?: boolean) {
+export function closeDefinition(definition: HTMLElement, forceFocus?: boolean) {
     definition.classList.remove(openClass);
     const termId = definition.getAttribute('term-id') || '';
     const term = document.getElementById(termId);
@@ -188,7 +188,7 @@ export function closeDefinition(definition: HTMLElement, focus?: boolean) {
 
     termParent.removeEventListener('scroll', termOnResize);
 
-    if (focus) {
+    if (forceFocus) {
         term?.focus(); // Set focus back to open button after closing popup
     }
 
@@ -213,7 +213,7 @@ function getCoords(elem: HTMLElement) {
     return {top: Math.round(top), left: Math.round(left)};
 }
 
-export function trapFocus(element: HTMLElement, termButton: HTMLElement) {
+export function trapFocus(element: HTMLElement) {
     const focusableElements = element.querySelectorAll(
         'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
     );

--- a/src/js/term/utils.ts
+++ b/src/js/term/utils.ts
@@ -176,7 +176,7 @@ export function openDefinition(target: HTMLElement) {
     trapFocus(definitionElement, target);
 }
 
-export function closeDefinition(definition: HTMLElement) {
+export function closeDefinition(definition: HTMLElement, focus?: boolean) {
     definition.classList.remove(openClass);
     const termId = definition.getAttribute('term-id') || '';
     const term = document.getElementById(termId);
@@ -187,7 +187,10 @@ export function closeDefinition(definition: HTMLElement) {
     }
 
     termParent.removeEventListener('scroll', termOnResize);
-    term?.focus(); // Set focus back to open button after closing popup
+
+    if (focus) {
+        term?.focus(); // Set focus back to open button after closing popup
+    }
 
     isListenerNeeded = true;
 }
@@ -216,12 +219,6 @@ export function trapFocus(element: HTMLElement, termButton: HTMLElement) {
     );
     const firstFocusableElement = focusableElements[0] as HTMLElement;
     const lastFocusableElement = focusableElements[focusableElements.length - 1] as HTMLElement;
-
-    // if another term was previously closed, the focus may still be on it
-    if (!firstFocusableElement && document.activeElement !== termButton) {
-        termButton.focus();
-        return;
-    }
 
     if (firstFocusableElement) {
         firstFocusableElement.focus();

--- a/src/js/term/utils.ts
+++ b/src/js/term/utils.ts
@@ -176,10 +176,9 @@ export function openDefinition(target: HTMLElement) {
     trapFocus(definitionElement);
 }
 
-export function closeDefinition(definition: HTMLElement, forceFocus?: boolean) {
+export function closeDefinition(definition: HTMLElement) {
     definition.classList.remove(openClass);
-    const termId = definition.getAttribute('term-id') || '';
-    const term = document.getElementById(termId);
+    const term = getTermByDefinition(definition);
     const termParent = termParentElement(term);
 
     if (!termParent) {
@@ -187,11 +186,6 @@ export function closeDefinition(definition: HTMLElement, forceFocus?: boolean) {
     }
 
     termParent.removeEventListener('scroll', termOnResize);
-
-    if (forceFocus) {
-        term?.focus(); // Set focus back to open button after closing popup
-    }
-
     isListenerNeeded = true;
 }
 
@@ -240,4 +234,10 @@ export function trapFocus(element: HTMLElement) {
             e.preventDefault();
         }
     });
+}
+
+export function getTermByDefinition(definition: HTMLElement) {
+    const termId = definition.getAttribute('term-id');
+
+    return termId ? document.getElementById(termId) : null;
 }


### PR DESCRIPTION
When the term is open, any click outside the term returns the focus to the definition of the term, which interferes with the operation of interactive elements.
Example: for the first click on the input, the focus immediately goes off

https://github.com/user-attachments/assets/2cf70dfe-f252-4d5a-87ce-6a5e00cf1c6e

I suggest returning focus only for keydown event, since it is only needed in this case.

