### PR TITLE
fix: lodash import

### DIFF
--- a/src/transform/liquid/index.ts
+++ b/src/transform/liquid/index.ts
@@ -1,6 +1,6 @@
 import type {Dictionary} from 'lodash';
 
-import {cloneDeepWith} from 'lodash';
+import cloneDeepWith from 'lodash/cloneDeepWith';
 
 import {composeFrontMatter, extractFrontMatter} from '../frontmatter';
 


### PR DESCRIPTION
After updating to a library version higher than 4.40.0, Statoscope checks started to fail - lodash was added.
![2025-01-14_11-02-23](https://github.com/user-attachments/assets/f6ad1066-8357-4f4a-a7db-e17e85e3a5a3)
