### PR TITLE
Change local package resolution alias in Playground to one that doesn't start with a tilde

### DIFF
--- a/playground/src/SplitViewEditor/generators.ts
+++ b/playground/src/SplitViewEditor/generators.ts
@@ -2,20 +2,19 @@ import MarkdownIt from 'markdown-it';
 import {mdRenderer} from '@diplodoc/markdown-it-markdown-renderer';
 import meta from 'markdown-it-meta';
 import sup from 'markdown-it-sup';
-
-import cut from '~transform/plugins/cut';
-import checkbox from '~transform/plugins/checkbox';
-import anchors from '~transform/plugins/anchors';
-import monospace from '~transform/plugins/monospace';
-import imsize from '~transform/plugins/imsize';
-import file from '~transform/plugins/file';
-import includes from '~transform/plugins/includes';
-import tabs from '~transform/plugins/tabs';
-import video from '~transform/plugins/video';
-import table from '~transform/plugins/table';
-import notes from '~transform/plugins/notes';
-import initMarkdownIt from '~transform/md';
-import transform from '~transform/index';
+import cut from '@local/transform/plugins/cut';
+import checkbox from '@local/transform/plugins/checkbox';
+import anchors from '@local/transform/plugins/anchors';
+import monospace from '@local/transform/plugins/monospace';
+import imsize from '@local/transform/plugins/imsize';
+import file from '@local/transform/plugins/file';
+import includes from '@local/transform/plugins/includes';
+import tabs from '@local/transform/plugins/tabs';
+import video from '@local/transform/plugins/video';
+import table from '@local/transform/plugins/table';
+import notes from '@local/transform/plugins/notes';
+import initMarkdownIt from '@local/transform/md';
+import transform from '@local/transform/index';
 
 const diplodocOptions = {
     lang: 'en',

--- a/playground/src/index.tsx
+++ b/playground/src/index.tsx
@@ -1,13 +1,12 @@
 import {createRoot} from 'react-dom/client';
 import {ThemeProvider} from '@gravity-ui/uikit';
+import '@local/transform-dist/js/yfm.js';
+import '@local/transform-dist/css/yfm.css';
 
 import {App} from './App';
 import './index.css';
 import './styles.scss';
 import './overrides.scss';
-
-import '~transform-dist/js/yfm.js';
-import '~transform-dist/css/yfm.css';
 
 const container = document.getElementById('app');
 const root = createRoot(container as HTMLElement);

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -14,8 +14,8 @@
     "skipLibCheck": true,
     "noImplicitAny": false,
     "paths": {
-      "~transform/*": ["../lib/*"],
-      "~transform-dist/*": ["../dist/*"]
+      "@local/transform/*": ["../lib/*"],
+      "@local/transform-dist/*": ["../dist/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],


### PR DESCRIPTION
#611 broke releases in master, since SCSS loader for Playground wasn't able to resolve an alias that starts with a tilde `~`.