### PR TITLE
Improve display styles for ordered lists

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -307,23 +307,26 @@
         margin-bottom: 0;
     }
 
-    &:not(.yfm_no-list-reset) {
-        ol {
-            list-style-type: none;
-            counter-reset: list;
+    ol {
+        counter-reset: list;
 
-            & > li {
-                position: relative;
-                counter-increment: list;
-
-                &::before {
-                    position: absolute;
-                    right: 100%;
-                    margin-right: 4px;
-                    content: counters(list, '.') '. ';
-                }
-            }
+        & > li {
+            position: relative;
+            counter-increment: list;
         }
+    }
+
+    ol > li > ol > li::marker {
+        content: counters(list, '.') '. ';
+    }
+
+    :not(ol > li) > ol > li::marker {
+        content: counter(list) '. ';
+    }
+
+    // No direct ancestor (>) combinator to preserve legacy behavior
+    ol.yfm_no-list-reset li::marker {
+        content: unset;
     }
 
     li {


### PR DESCRIPTION
This PR addresses two kinds of issues:

1. Lists spanning over block element boundaries
   <img width="619" alt="изображение" src="https://github.com/user-attachments/assets/fccfc7ab-bc6b-4165-8823-ffaefbe9f196" />
2. Lack of list marker centering relative to the list item content
   <img width="251" alt="изображение" src="https://github.com/user-attachments/assets/abf3b75f-7951-4c6c-92ce-3d14bf33e5da" />

Before:
<img width="1310" alt="изображение" src="https://github.com/user-attachments/assets/a6576359-b0d8-409c-89b0-30e7f61c0e56" />

After:
<img width="1331" alt="изображение" src="https://github.com/user-attachments/assets/2be77674-752e-4610-87ae-c63777bc93fe" />

