### PR TITLE
Restore list margins when nested within certain elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@diplodoc/cut-extension": "^0.7.1",
+        "@diplodoc/cut-extension": "^0.7.2",
         "@diplodoc/file-extension": "^0.2.0",
         "@diplodoc/tabs-extension": "^3.5.0",
         "chalk": "^4.1.2",
@@ -3074,9 +3074,9 @@
       }
     },
     "node_modules/@diplodoc/cut-extension": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/cut-extension/-/cut-extension-0.7.1.tgz",
-      "integrity": "sha512-GPwmCDIfxaBZ+t+tNxLgqnZLT7UE8eFXR/OtkzEJHBEEUTBQCOdpkETg3RAcFdbPYhLiUcw5CN5V8pFdPGKoWw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@diplodoc/cut-extension/-/cut-extension-0.7.2.tgz",
+      "integrity": "sha512-ppe/lN7mvLi7bulEA0EB8Q7m9I9E4U3BqtXrE4gzBCDqkBaHXuIJakYSbOsDnBs5Tb5T8TfSUqXHH6iP8Wz8CQ==",
       "dependencies": {
         "@diplodoc/directive": "^0.3.0",
         "@diplodoc/utils": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "postinstall": "cd playground && npm ci --ignore-scripts || true"
   },
   "dependencies": {
-    "@diplodoc/cut-extension": "^0.7.1",
+    "@diplodoc/cut-extension": "^0.7.2",
     "@diplodoc/file-extension": "^0.2.0",
     "@diplodoc/tabs-extension": "^3.5.0",
     "chalk": "^4.1.2",

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -286,12 +286,6 @@
 
     dd {
         margin-left: 0;
-
-        & > ol:first-child,
-        & > ul:first-child,
-        & > dd:first-child {
-            padding-left: 0;
-        }
     }
 
     ul,
@@ -324,9 +318,13 @@
         content: counter(list) '. ';
     }
 
-    // No direct ancestor (>) combinator to preserve legacy behavior
-    ol.yfm_no-list-reset li::marker {
-        content: unset;
+    ol.yfm_no-list-reset {
+        counter-reset: unset;
+
+        // No direct ancestor (>) combinator to preserve legacy behavior
+        & li::marker {
+            content: unset;
+        }
     }
 
     li {

--- a/src/scss/print/cut.scss
+++ b/src/scss/print/cut.scss
@@ -17,17 +17,3 @@
         }
     }
 }
-
-.yfm-cut-content {
-    .yfm:not(.yfm_no-list-reset) & ol {
-        counter-reset: cut-list;
-
-        & > li {
-            counter-increment: cut-list;
-
-            &::before {
-                content: counters(cut-list, '.') '. ';
-            }
-        }
-    }
-}


### PR DESCRIPTION
Additionally, redundant styles in `cut-extension` were stripped, as they were clashing with solution provided in #628. Marker content in lists with `yfm_no-list-reset` was also restored to its stock behavior.