### PR TITLE
feat: multilines in checkbox

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -164,7 +164,7 @@
 
         &[type='checkbox'] {
             position: relative;
-            top: 1px;
+            top: 4px;
 
             box-sizing: border-box;
             padding: 0;


### PR DESCRIPTION
This change allows you to parse multiple lines using only one checkbox.

Currently, work on this feature has been suspended and its implementation has not been completed.
