### PR TITLE
feat: added option to disable markdown-it-attrs

### DIFF
--- a/src/transform/md.ts
+++ b/src/transform/md.ts
@@ -95,10 +95,15 @@ function initPlugins(md: MarkdownIt, options: OptionsType, pluginOptions: Markdo
         leftDelimiter = '{',
         rightDelimiter = '}',
         plugins = DefaultPlugins,
+        enableMarkdownAttrs,
     } = options;
 
-    // Need for ids of headers
-    md.use(attrs, {leftDelimiter, rightDelimiter});
+    // TODO: set enableMarkdownAttrs to false by default in next major
+    if (enableMarkdownAttrs !== false) {
+        // Need for ids of headers
+        md.use(attrs, {leftDelimiter, rightDelimiter});
+    }
+
     md.use(olAttrConversion);
 
     plugins.forEach((plugin) => md.use(plugin, pluginOptions));

--- a/src/transform/plugins/block-anchor/index.ts
+++ b/src/transform/plugins/block-anchor/index.ts
@@ -3,7 +3,11 @@ import MarkdownIt from 'markdown-it';
 import {TOKEN_NAME, renderTokens, replaceTokens} from './block-anchor';
 
 const blockAnchor = (md: MarkdownIt) => {
-    md.core.ruler.before('curly_attributes', TOKEN_NAME, replaceTokens);
+    try {
+        md.core.ruler.before('curly_attributes', TOKEN_NAME, replaceTokens);
+    } catch (e) {
+        md.core.ruler.push(TOKEN_NAME, replaceTokens);
+    }
     md.renderer.rules[TOKEN_NAME] = renderTokens;
 
     return md;

--- a/src/transform/plugins/includes/index.ts
+++ b/src/transform/plugins/includes/index.ts
@@ -76,6 +76,7 @@ function unfoldIncludes(md: MarkdownItIncluded, state: StateCore, path: string, 
                 let includedTokens;
                 if (hash) {
                     // TODO: add warning about missed block
+                    // TODO: findBlockTokens requires markdown-it-attrs plugin for find block with id=hash
                     includedTokens = findBlockTokens(fileTokens, hash);
                 } else {
                     includedTokens = fileTokens;

--- a/src/transform/typings.ts
+++ b/src/transform/typings.ts
@@ -59,6 +59,13 @@ export interface OptionsType {
     getPublicPath?: (options: OptionsType, href?: string) => string;
     renderInline?: boolean;
     cache?: CacheContext;
+    // TODO: set false by default in next major
+    /**
+     * `markdown-it-attrs` plugin is enabled by default
+     *
+     * Set value to `false` to disable it
+     */
+    enableMarkdownAttrs?: boolean;
     [x: string]: unknown;
 }
 

--- a/src/transform/yfmlint/index.ts
+++ b/src/transform/yfmlint/index.ts
@@ -56,7 +56,9 @@ function yfmlint(opts: Options) {
         lintRules = union(lintRules, customLintRules);
     }
 
-    const plugins = customPlugins && [attrs, ...customPlugins];
+    // TODO: set to false in next major
+    const {enableMarkdownAttrs = true} = opts;
+    const plugins = customPlugins && [...(enableMarkdownAttrs ? [attrs] : []), ...customPlugins];
     const preparedPlugins = plugins && plugins.map((plugin) => [plugin, pluginOptions]);
 
     // Run preprocessor

--- a/src/transform/yfmlint/typings.ts
+++ b/src/transform/yfmlint/typings.ts
@@ -16,4 +16,7 @@ export interface Options {
     lintConfig?: LintConfig;
     customLintRules?: Rule[];
     sourceMap?: Dictionary<string>;
+    // TODO: set false in next major
+    /** @default true */
+    enableMarkdownAttrs?: boolean;
 }

--- a/test/__snapshots__/block-anchor.test.ts.snap
+++ b/test/__snapshots__/block-anchor.test.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`block-anchor does not parse produce an anchor if there is content before markup 1`] = `
+exports[`block-anchor markdown-it-attrs in enabled does not parse produce an anchor if there is content before markup 1`] = `
 <p>
   Content
 </p>
 `;
 
-exports[`block-anchor handles multiple anchors in the input 1`] = `
+exports[`block-anchor markdown-it-attrs in enabled handles multiple anchors in the input 1`] = `
 <hr id="first-anchor"
     class="visually-hidden"
 >
@@ -24,7 +24,7 @@ exports[`block-anchor handles multiple anchors in the input 1`] = `
 >
 `;
 
-exports[`block-anchor parses anchors surrounded by other blocks 1`] = `
+exports[`block-anchor markdown-it-attrs in enabled parses anchors surrounded by other blocks 1`] = `
 <h1 id="heading">
   <a href="#heading"
      class="yfm-anchor"
@@ -46,19 +46,96 @@ exports[`block-anchor parses anchors surrounded by other blocks 1`] = `
 </p>
 `;
 
-exports[`block-anchor parses block anchors 1`] = `
+exports[`block-anchor markdown-it-attrs in enabled parses block anchors 1`] = `
 <p>
   \${%anchor my-anchor} Content
 </p>
 `;
 
-exports[`block-anchor renders block-anchor 1`] = `
+exports[`block-anchor markdown-it-attrs in enabled renders block-anchor 1`] = `
 <hr id="my-anchor"
     class="visually-hidden"
 >
 `;
 
-exports[`block-anchor works with heading anchors 1`] = `
+exports[`block-anchor markdown-it-attrs in enabled works with heading anchors 1`] = `
+<h1 id="heading-anchor">
+  <a href="#heading-anchor"
+     class="yfm-anchor"
+     aria-hidden="true"
+  >
+    <span class="visually-hidden"
+          data-no-index="true"
+    >
+      Heading
+    </span>
+  </a>
+  Heading
+</h1>
+<hr id="my-anchor"
+    class="visually-hidden"
+>
+`;
+
+exports[`block-anchor markdown-it-attrs is disabled does not parse produce an anchor if there is content before markup 1`] = `
+<p>
+  Content  {%anchor my-anchor%}
+</p>
+`;
+
+exports[`block-anchor markdown-it-attrs is disabled handles multiple anchors in the input 1`] = `
+<hr id="first-anchor"
+    class="visually-hidden"
+>
+<p>
+  Some content
+</p>
+<hr id="second-anchor"
+    class="visually-hidden"
+>
+<p>
+  Some more content
+</p>
+<hr id="third-anchor"
+    class="visually-hidden"
+>
+`;
+
+exports[`block-anchor markdown-it-attrs is disabled parses anchors surrounded by other blocks 1`] = `
+<h1 id="heading">
+  <a href="#heading"
+     class="yfm-anchor"
+     aria-hidden="true"
+  >
+    <span class="visually-hidden"
+          data-no-index="true"
+    >
+      Heading
+    </span>
+  </a>
+  Heading
+</h1>
+<hr id="my-anchor"
+    class="visually-hidden"
+>
+<p>
+  paragraph with content
+</p>
+`;
+
+exports[`block-anchor markdown-it-attrs is disabled parses block anchors 1`] = `
+<p>
+  \${%anchor my-anchor} Content
+</p>
+`;
+
+exports[`block-anchor markdown-it-attrs is disabled renders block-anchor 1`] = `
+<hr id="my-anchor"
+    class="visually-hidden"
+>
+`;
+
+exports[`block-anchor markdown-it-attrs is disabled works with heading anchors 1`] = `
 <h1 id="heading-anchor">
   <a href="#heading-anchor"
      class="yfm-anchor"

--- a/test/__snapshots__/xss.test.ts.snap
+++ b/test/__snapshots__/xss.test.ts.snap
@@ -1,98 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` & JavaScript includes 1`] = `<br size="&amp;{alert('XSS')}">`;
+exports[`XSS checks with disabled markdown-it-attrs & JavaScript includes 1`] = `<br size="&amp;{alert('XSS')}">`;
 
-exports[` Anonymous HTML with style attribute 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs Anonymous HTML with style attribute 1`] = `""`;
 
-exports[` Assuming you can only fit in a few characters and it filters against ".js" 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs Assuming you can only fit in a few characters and it filters against ".js" 1`] = `""`;
 
-exports[` BASE tag 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs BASE tag 1`] = `""`;
 
-exports[` BGSOUND 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs BGSOUND 1`] = `""`;
 
-exports[` Case insensitive XSS attack vector 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Case insensitive XSS attack vector 1`] = `
 <p>
   &lt;img src=JaVaScRiPt:alert('XSS')&gt;
 </p>
 `;
 
-exports[` DIV background-image 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs DIV background-image 1`] = `
 <div>
 </div>
 `;
 
-exports[` DIV background-image with unicoded XSS exploit 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs DIV background-image with unicoded XSS exploit 1`] = `
 <div style="background-image:\\0075\\0072\\006C\\0028'\\006a\\0061\\0076\\0061\\0073\\0063\\0072\\0069\\0070\\0074\\003a\\0061\\006c\\0065\\0072\\0074\\0028.1027\\0058.1053\\0053\\0027\\0029'\\0029">
 </div>
 `;
 
-exports[` DIV background-image with unicoded XSS exploit 2 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs DIV background-image with unicoded XSS exploit 2 1`] = `
 <div>
 </div>
 `;
 
-exports[` DIV expression 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs DIV expression 1`] = `
 <div style="width:expression(alert('XSS'))">
 </div>
 `;
 
-exports[` Decimal HTML character references 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Decimal HTML character references 1`] = `<img>`;
 
-exports[` Decimal HTML character references without trailing semicolons 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Decimal HTML character references without trailing semicolons 1`] = `<img>`;
 
-exports[` Default src tag by leaving it empty 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Default src tag by leaving it empty 1`] = `
 <p>
   &lt;img src= onmouseover="alert('xxs')"&gt;
 </p>
 `;
 
-exports[` Default src tag by leaving it out entirely 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Default src tag by leaving it out entirely 1`] = `<img>`;
 
-exports[` Default src tag to get past filters that check src domain 1`] = `<img src="#">`;
+exports[`XSS checks with disabled markdown-it-attrs Default src tag to get past filters that check src domain 1`] = `<img src="#">`;
 
-exports[` Double open angle brackets 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs Double open angle brackets 1`] = `""`;
 
-exports[` Downlevel-Hidden block 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs Downlevel-Hidden block 1`] = `""`;
 
-exports[` Embedded Encoded tab 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Embedded Encoded tab 1`] = `<img>`;
 
-exports[` Embedded carriage return to break up XSS 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Embedded carriage return to break up XSS 1`] = `<img>`;
 
-exports[` Embedded newline to break up XSS 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Embedded newline to break up XSS 1`] = `<img>`;
 
-exports[` Embedded tab 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Embedded tab 1`] = `<img>`;
 
-exports[` End title tag 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs End title tag 1`] = `""`;
 
-exports[` Escaping JavaScript escapes 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Escaping JavaScript escapes 1`] = `
 <p>
   ";alert('XSS');//
 </p>
 `;
 
-exports[` Grave accent obfuscation 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Grave accent obfuscation 1`] = `
 <p>
   &lt;img src='javascript:alert("RSnake says, 'XSS'")'&gt;
 </p>
 `;
 
-exports[` HTML entities 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs HTML entities 1`] = `
 <p>
   &lt;img src=javascript:alert("XSS")&gt;
 </p>
 `;
 
-exports[` Half open HTML/JavaScript XSS vector 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Half open HTML/JavaScript XSS vector 1`] = `
 <p>
   &lt;img src="javascript:alert('XSS')"
 </p>
 `;
 
-exports[` Hexadecimal HTML character references without trailing semicolons 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Hexadecimal HTML character references without trailing semicolons 1`] = `<img>`;
 
-exports[` Image XSS using the JavaScript directive 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Image XSS using the JavaScript directive 1`] = `<img>`;
 
-exports[` List-style-image 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs List-style-image 1`] = `
 <style>
 </style>
 <ul>
@@ -103,11 +103,11 @@ exports[` List-style-image 1`] = `
 </ul>
 `;
 
-exports[` Livescript 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Livescript 1`] = `<img>`;
 
-exports[` Local htc file 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs Local htc file 1`] = `""`;
 
-exports[` Malformed A tags 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Malformed A tags 1`] = `
 <p>
   <a>
     xxs link
@@ -115,81 +115,81 @@ exports[` Malformed A tags 1`] = `
 </p>
 `;
 
-exports[` Malformed img tags 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Malformed img tags 1`] = `
 <p>
   &lt;img """&gt;"&gt;
 </p>
 `;
 
-exports[` No Filter Evasion 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs No Filter Evasion 1`] = `""`;
 
-exports[` No closing script tags 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs No closing script tags 1`] = `""`;
 
-exports[` No quotes and no semicolon 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs No quotes and no semicolon 1`] = `
 <p>
   &lt;img src=javascript:alert('XSS')&gt;
 </p>
 `;
 
-exports[` Non-alpha-non-digit XSS 1 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Non-alpha-non-digit XSS 1 1`] = `
 <p>
   &lt;script/xss src="http://ha.ckers.org/xss.js"&gt;
 </p>
 `;
 
-exports[` Non-alpha-non-digit XSS 2 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs Non-alpha-non-digit XSS 2 1`] = `""`;
 
-exports[` Non-alpha-non-digit XSS 3 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Non-alpha-non-digit XSS 3 1`] = `
 <p>
   &lt;script/src="http://ha.ckers.org/xss.js"&gt;
 </p>
 `;
 
-exports[` Non-alpha-non-digit XSS 4 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Non-alpha-non-digit XSS 4 1`] = `
 <p>
   &lt;
 </p>
 `;
 
-exports[` Null breaks up JavaScript directive 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Null breaks up JavaScript directive 1`] = `
 <p>
   perl -e 'print "&lt;img src=java�script:alert("XSS")&gt;";' &gt; out
 </p>
 `;
 
-exports[` OBJECT tag 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs OBJECT tag 1`] = `
 <p>
 </p>
 `;
 
-exports[` PHP 1`] = `"alert(\\"XSS\\")'); ?&gt;"`;
+exports[`XSS checks with disabled markdown-it-attrs PHP 1`] = `"alert(\\"XSS\\")'); ?&gt;"`;
 
-exports[` Protocol resolution in script tags 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs Protocol resolution in script tags 1`] = `""`;
 
-exports[` Remote style sheet 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs Remote style sheet 1`] = `""`;
 
-exports[` Remote style sheet part 2 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Remote style sheet part 2 1`] = `
 <style>
 </style>
 `;
 
-exports[` Remote style sheet part 3 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs Remote style sheet part 3 1`] = `""`;
 
-exports[` Remote style sheet part 4 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Remote style sheet part 4 1`] = `
 <style>
 </style>
 `;
 
-exports[` SSI (Server Side Includes) 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs SSI (Server Side Includes) 1`] = `""`;
 
-exports[` Spaces and meta chars before the JavaScript in images for XSS 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs Spaces and meta chars before the JavaScript in images for XSS 1`] = `<img>`;
 
-exports[` TABLE 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs TABLE 1`] = `
 <table background="javascript:alert('XSS')">
 </table>
 `;
 
-exports[` TD 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs TD 1`] = `
 <table>
   <tbody>
     <tr>
@@ -200,65 +200,65 @@ exports[` TD 1`] = `
 </table>
 `;
 
-exports[` US-ASCII encoding 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs US-ASCII encoding 1`] = `
 <p>
   ¼script¾alert(¢XSS¢)¼/script¾
 </p>
 `;
 
-exports[` Using an EMBED tag you can embed a Flash movie that contains XSS 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs Using an EMBED tag you can embed a Flash movie that contains XSS 1`] = `
 <p>
   &lt;embed src="http://ha.ckers.Using an EMBED tag you can embed a Flash movie that contains XSS. Click here for a demo. If you add the attributes allowScriptAccess="never" and allownetworking="internal" it can mitigate this risk (thank you to Jonathan Vanasco for the info).:org/xss.swf" AllowScriptAccess="always"&gt;
 </p>
 `;
 
-exports[` VBscript in an image 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs VBscript in an image 1`] = `<img>`;
 
-exports[` XML tag 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs XML tag 1`] = `
 <p>
 </p>
 `;
 
-exports[` XSS Locator 1 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs XSS Locator 1 1`] = `
 <p>
   ';alert(String.fromCharCode(88,83,83))//';alert(String.fromCharCode(88,83,83))//";alert(String.fromCharCode(88,83,83))//";alert(String.fromCharCode(88,83,83))//--&gt;"&gt;'&gt;
 </p>
 `;
 
-exports[` XSS locator 2 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs XSS locator 2 1`] = `
 <p>
-  '';!--"=&amp;
+  '';!--"=&amp;{()}
 </p>
 `;
 
-exports[` You can EMBED SVG which can contain your XSS vector 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs You can EMBED SVG which can contain your XSS vector 1`] = `
 <p>
 </p>
 `;
 
-exports[` body image 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs body image 1`] = `""`;
 
-exports[` body tag 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs body tag 1`] = `""`;
 
-exports[` frame 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs frame 1`] = `""`;
 
-exports[` fromCharCode 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs fromCharCode 1`] = `<img>`;
 
-exports[` iframe 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs iframe 1`] = `
 <iframe>
 </iframe>
 `;
 
-exports[` iframe Event based 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs iframe Event based 1`] = `
 <iframe src="#">
 </iframe>
 `;
 
-exports[` img Dynsrc 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs img Dynsrc 1`] = `<img>`;
 
-exports[` img lowsrc 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs img lowsrc 1`] = `<img>`;
 
-exports[` img style with expression 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs img style with expression 1`] = `
 <p>
   exp/
   <em>
@@ -268,7 +268,7 @@ exports[` img style with expression 1`] = `
 </p>
 `;
 
-exports[` img style with expression 2`] = `
+exports[`XSS checks with disabled markdown-it-attrs img style with expression 2`] = `
 <p>
   exp/
   <em>
@@ -278,20 +278,20 @@ exports[` img style with expression 2`] = `
 </p>
 `;
 
-exports[` input image 1`] = `<input type="image">`;
+exports[`XSS checks with disabled markdown-it-attrs input image 1`] = `<input type="image">`;
 
-exports[` meta 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs meta 1`] = `""`;
 
-exports[` style sheet 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs style sheet 1`] = `""`;
 
-exports[` style tag 1`] = `""`;
+exports[`XSS checks with disabled markdown-it-attrs style tag 1`] = `""`;
 
-exports[` style tag using background 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs style tag using background 1`] = `
 <style type="text/css">
 </style>
 `;
 
-exports[` style tag using background-image 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs style tag using background-image 1`] = `
 <style>
   .xss {
   background-image: url("javascript:alert('XSS')");
@@ -301,14 +301,331 @@ exports[` style tag using background-image 1`] = `
 </a>
 `;
 
-exports[` style tags with broken up JavaScript for XSS 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs style tags with broken up JavaScript for XSS 1`] = `
 <style>
 </style>
 `;
 
-exports[` style tags with broken up JavaScript for XSS part 2 1`] = `<img>`;
+exports[`XSS checks with disabled markdown-it-attrs style tags with broken up JavaScript for XSS part 2 1`] = `<img>`;
 
-exports[` svg with style tag and foreignObject inside 1`] = `
+exports[`XSS checks with disabled markdown-it-attrs svg with style tag and foreignObject inside 1`] = `
+<p>
+  <svg>
+    <style>
+    </style>
+  </svg>
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs & JavaScript includes 1`] = `<br size="&amp;{alert('XSS')}">`;
+
+exports[`XSS checks with enabled markdown-it-attrs Anonymous HTML with style attribute 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Assuming you can only fit in a few characters and it filters against ".js" 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs BASE tag 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs BGSOUND 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Case insensitive XSS attack vector 1`] = `
+<p>
+  &lt;img src=JaVaScRiPt:alert('XSS')&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs DIV background-image 1`] = `
+<div>
+</div>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs DIV background-image with unicoded XSS exploit 1`] = `
+<div style="background-image:\\0075\\0072\\006C\\0028'\\006a\\0061\\0076\\0061\\0073\\0063\\0072\\0069\\0070\\0074\\003a\\0061\\006c\\0065\\0072\\0074\\0028.1027\\0058.1053\\0053\\0027\\0029'\\0029">
+</div>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs DIV background-image with unicoded XSS exploit 2 1`] = `
+<div>
+</div>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs DIV expression 1`] = `
+<div style="width:expression(alert('XSS'))">
+</div>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Decimal HTML character references 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs Decimal HTML character references without trailing semicolons 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs Default src tag by leaving it empty 1`] = `
+<p>
+  &lt;img src= onmouseover="alert('xxs')"&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Default src tag by leaving it out entirely 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs Default src tag to get past filters that check src domain 1`] = `<img src="#">`;
+
+exports[`XSS checks with enabled markdown-it-attrs Double open angle brackets 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Downlevel-Hidden block 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Embedded Encoded tab 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs Embedded carriage return to break up XSS 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs Embedded newline to break up XSS 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs Embedded tab 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs End title tag 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Escaping JavaScript escapes 1`] = `
+<p>
+  ";alert('XSS');//
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Grave accent obfuscation 1`] = `
+<p>
+  &lt;img src='javascript:alert("RSnake says, 'XSS'")'&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs HTML entities 1`] = `
+<p>
+  &lt;img src=javascript:alert("XSS")&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Half open HTML/JavaScript XSS vector 1`] = `
+<p>
+  &lt;img src="javascript:alert('XSS')"
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Hexadecimal HTML character references without trailing semicolons 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs Image XSS using the JavaScript directive 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs List-style-image 1`] = `
+<style>
+</style>
+<ul>
+  <li>
+    XSS
+    <br>
+  </li>
+</ul>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Livescript 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs Local htc file 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Malformed A tags 1`] = `
+<p>
+  <a>
+    xxs link
+  </a>
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Malformed img tags 1`] = `
+<p>
+  &lt;img """&gt;"&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs No Filter Evasion 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs No closing script tags 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs No quotes and no semicolon 1`] = `
+<p>
+  &lt;img src=javascript:alert('XSS')&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Non-alpha-non-digit XSS 1 1`] = `
+<p>
+  &lt;script/xss src="http://ha.ckers.org/xss.js"&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Non-alpha-non-digit XSS 2 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Non-alpha-non-digit XSS 3 1`] = `
+<p>
+  &lt;script/src="http://ha.ckers.org/xss.js"&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Non-alpha-non-digit XSS 4 1`] = `
+<p>
+  &lt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Null breaks up JavaScript directive 1`] = `
+<p>
+  perl -e 'print "&lt;img src=java�script:alert("XSS")&gt;";' &gt; out
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs OBJECT tag 1`] = `
+<p>
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs PHP 1`] = `"alert(\\"XSS\\")'); ?&gt;"`;
+
+exports[`XSS checks with enabled markdown-it-attrs Protocol resolution in script tags 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Remote style sheet 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Remote style sheet part 2 1`] = `
+<style>
+</style>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Remote style sheet part 3 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Remote style sheet part 4 1`] = `
+<style>
+</style>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs SSI (Server Side Includes) 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs Spaces and meta chars before the JavaScript in images for XSS 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs TABLE 1`] = `
+<table background="javascript:alert('XSS')">
+</table>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs TD 1`] = `
+<table>
+  <tbody>
+    <tr>
+      <td background="javascript:alert('XSS')">
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs US-ASCII encoding 1`] = `
+<p>
+  ¼script¾alert(¢XSS¢)¼/script¾
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs Using an EMBED tag you can embed a Flash movie that contains XSS 1`] = `
+<p>
+  &lt;embed src="http://ha.ckers.Using an EMBED tag you can embed a Flash movie that contains XSS. Click here for a demo. If you add the attributes allowScriptAccess="never" and allownetworking="internal" it can mitigate this risk (thank you to Jonathan Vanasco for the info).:org/xss.swf" AllowScriptAccess="always"&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs VBscript in an image 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs XML tag 1`] = `
+<p>
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs XSS Locator 1 1`] = `
+<p>
+  ';alert(String.fromCharCode(88,83,83))//';alert(String.fromCharCode(88,83,83))//";alert(String.fromCharCode(88,83,83))//";alert(String.fromCharCode(88,83,83))//--&gt;"&gt;'&gt;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs XSS locator 2 1`] = `
+<p>
+  '';!--"=&amp;
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs You can EMBED SVG which can contain your XSS vector 1`] = `
+<p>
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs body image 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs body tag 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs frame 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs fromCharCode 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs iframe 1`] = `
+<iframe>
+</iframe>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs iframe Event based 1`] = `
+<iframe src="#">
+</iframe>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs img Dynsrc 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs img lowsrc 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs img style with expression 1`] = `
+<p>
+  exp/
+  <em>
+    &lt;a style='no\\xss:noxss("
+  </em>
+  //*");
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs img style with expression 2`] = `
+<p>
+  exp/
+  <em>
+    &lt;a style='no\\xss:noxss("
+  </em>
+  //*");
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs input image 1`] = `<input type="image">`;
+
+exports[`XSS checks with enabled markdown-it-attrs meta 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs style sheet 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs style tag 1`] = `""`;
+
+exports[`XSS checks with enabled markdown-it-attrs style tag using background 1`] = `
+<style type="text/css">
+</style>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs style tag using background-image 1`] = `
+<style>
+  .xss {
+  background-image: url("javascript:alert('XSS')");
+}
+</style>
+<a class="XSS">
+</a>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs style tags with broken up JavaScript for XSS 1`] = `
+<style>
+</style>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs style tags with broken up JavaScript for XSS part 2 1`] = `<img>`;
+
+exports[`XSS checks with enabled markdown-it-attrs svg with style tag and foreignObject inside 1`] = `
 <p>
   <svg>
     <style>

--- a/test/anchors.test.ts
+++ b/test/anchors.test.ts
@@ -8,7 +8,7 @@ import transform from '../src/transform';
 import {getPublicPath} from '../src/transform/utilsFS';
 
 const mocksPath = require.resolve('./mocks/link.md');
-const html = (text: string) => {
+const html = (text: string, opts?: transform.Options) => {
     const {
         result: {html},
     } = transform(text, {
@@ -16,6 +16,8 @@ const html = (text: string) => {
         path: mocksPath,
         root: dirname(mocksPath),
         getPublicPath,
+        enableMarkdownAttrs: false,
+        ...opts,
     });
     return html;
 };
@@ -101,13 +103,16 @@ describe('Anchors', () => {
 
     it('should include content by anchor in sharped path file', () => {
         expect(
-            html(dedent`
+            html(
+                dedent`
             Content before include
 
             {% include [file](./folder-with-#-sharp/file-with-#-sharp.md#anchor) %}
 
             After include
-        `),
+        `,
+                {enableMarkdownAttrs: true},
+            ), // TODO: includes requires markdown-it-attrs plugin for find block with id=hash
         ).toMatchSnapshot();
     });
 
@@ -152,6 +157,7 @@ describe('Anchors', () => {
                 path: mocksPath,
                 root: dirname(mocksPath),
                 extractTitle: true,
+                enableMarkdownAttrs: false,
             });
             return [html, title];
         };
@@ -177,6 +183,7 @@ describe('Anchors', () => {
                 root: dirname(mocksPath),
                 getPublicPath,
                 disableCommonAnchors: true,
+                enableMarkdownAttrs: false,
             });
 
             expect(html).toEqual('<h2 id="test-heading">Test heading</h2>\n');
@@ -191,6 +198,7 @@ describe('Anchors', () => {
                 root: dirname(mocksPath),
                 getPublicPath,
                 disableCommonAnchors: true,
+                enableMarkdownAttrs: false,
             });
 
             expect(html).toEqual('<h2 id="custom-id">Test heading</h2>\n');

--- a/test/block-anchor.test.ts
+++ b/test/block-anchor.test.ts
@@ -2,48 +2,56 @@ import initMarkdown from '../src/transform/md';
 import plugin from '../src/transform/plugins/block-anchor';
 import anchorsPlugin from '../src/transform/plugins/anchors';
 
-const {parse, compile} = initMarkdown({plugins: [plugin, anchorsPlugin]});
+describe('block-anchor', () => {
+    describe.each([
+        ['markdown-it-attrs is disabled', false],
+        ['markdown-it-attrs in enabled', true],
+    ])('%s', (_0, enableMarkdownAttrs) => {
+        const {parse, compile} = initMarkdown({
+            plugins: [plugin, anchorsPlugin],
+            enableMarkdownAttrs,
+        });
 
-describe('block-anchor', function () {
-    it('renders block-anchor', () => {
-        const input = '{%anchor my-anchor%}';
-        const actual = compile(parse(input));
+        it('renders block-anchor', () => {
+            const input = '{%anchor my-anchor%}';
+            const actual = compile(parse(input));
 
-        expect(actual).toMatchSnapshot();
-    });
+            expect(actual).toMatchSnapshot();
+        });
 
-    it('parses anchors surrounded by other blocks', () => {
-        const input = '# Heading \n\n {%anchor my-anchor%} \n\n paragraph with content';
-        const actual = compile(parse(input));
-        expect(actual).toMatchSnapshot();
-    });
+        it('parses anchors surrounded by other blocks', () => {
+            const input = '# Heading \n\n {%anchor my-anchor%} \n\n paragraph with content';
+            const actual = compile(parse(input));
+            expect(actual).toMatchSnapshot();
+        });
 
-    it('parses block anchors', () => {
-        const input = '${%anchor my-anchor} Content';
-        const actual = compile(parse(input));
+        it('parses block anchors', () => {
+            const input = '${%anchor my-anchor} Content';
+            const actual = compile(parse(input));
 
-        expect(actual).toMatchSnapshot();
-    });
+            expect(actual).toMatchSnapshot();
+        });
 
-    it('works with heading anchors', () => {
-        const input = '# Heading {#heading-anchor} \n {%anchor my-anchor%}';
-        const actual = compile(parse(input));
+        it('works with heading anchors', () => {
+            const input = '# Heading {#heading-anchor} \n {%anchor my-anchor%}';
+            const actual = compile(parse(input));
 
-        expect(actual).toMatchSnapshot();
-    });
+            expect(actual).toMatchSnapshot();
+        });
 
-    it('does not parse produce an anchor if there is content before markup', () => {
-        const input = 'Content  {%anchor my-anchor%}';
-        const actual = compile(parse(input));
+        it('does not parse produce an anchor if there is content before markup', () => {
+            const input = 'Content  {%anchor my-anchor%}';
+            const actual = compile(parse(input));
 
-        expect(actual).toMatchSnapshot();
-    });
+            expect(actual).toMatchSnapshot();
+        });
 
-    it('handles multiple anchors in the input', () => {
-        const input =
-            '{%anchor first-anchor%}\n\nSome content\n\n{%anchor second-anchor%}\n\nSome more content\n\n{%anchor third-anchor%}';
-        const actual = compile(parse(input));
+        it('handles multiple anchors in the input', () => {
+            const input =
+                '{%anchor first-anchor%}\n\nSome content\n\n{%anchor second-anchor%}\n\nSome more content\n\n{%anchor third-anchor%}';
+            const actual = compile(parse(input));
 
-        expect(actual).toMatchSnapshot();
+            expect(actual).toMatchSnapshot();
+        });
     });
 });

--- a/test/sanitize-html.test.ts
+++ b/test/sanitize-html.test.ts
@@ -6,6 +6,7 @@ const html = (text: string, options?: Parameters<typeof transform>[1]) => {
         result: {html},
     } = transform(text, {
         allowHTML: true,
+        enableMarkdownAttrs: false,
         ...options,
     });
     return html;
@@ -39,17 +40,24 @@ describe('Sanitize HTML utility', () => {
 
         describe('plugin markdown-it-attrs', () => {
             it('should sanitize danger attributes', () => {
-                expect(html('Click {onfocus="alert(1)" onclick="alert(1)"}')).toMatchSnapshot();
+                expect(
+                    html('Click {onfocus="alert(1)" onclick="alert(1)"}', {
+                        enableMarkdownAttrs: true,
+                    }),
+                ).toMatchSnapshot();
             });
 
             it('should not sanitize safe attributes', () => {
-                expect(html('Click {.style-me data-toggle=modal}')).toMatchSnapshot();
+                expect(
+                    html('Click {.style-me data-toggle=modal}', {enableMarkdownAttrs: true}),
+                ).toMatchSnapshot();
             });
 
             it('should sanitize danger style attributes', () => {
                 expect(
                     html(
                         '[example.com](https://example.com){style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: red; opacity: 0.5"}',
+                        {enableMarkdownAttrs: true},
                     ),
                 ).toMatchSnapshot();
             });
@@ -82,7 +90,7 @@ describe('Sanitize HTML utility', () => {
                 expect(
                     html(
                         '[example.com](https://example.com){style="position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: red; opacity: 0.5"}',
-                        {sanitizeOptions},
+                        {sanitizeOptions, enableMarkdownAttrs: true},
                     ),
                 ).toMatchSnapshot();
             });

--- a/test/table/table.test.ts
+++ b/test/table/table.test.ts
@@ -7,6 +7,7 @@ const transformYfm = (text: string) => {
         result: {html},
     } = transform(text, {
         plugins: [table],
+        enableMarkdownAttrs: false,
     });
     return html;
 };
@@ -1312,6 +1313,7 @@ const transformWithIncludes = (text: string) => {
     } = transform(text, {
         plugins: [table, includes],
         path: mocksPath,
+        enableMarkdownAttrs: false,
     });
     return html;
 };

--- a/test/xss.test.ts
+++ b/test/xss.test.ts
@@ -161,10 +161,13 @@ const ckecks = [
     ['PHP', `<? echo('<SCR)';\necho('IPT>alert("XSS")</SCRIPT>'); ?>`],
 ];
 
-describe('', () => {
+describe.each([
+    ['enabled', true],
+    ['disabled', false],
+])('XSS checks with %s markdown-it-attrs', (_0, enableMarkdownAttrs) => {
     ckecks.forEach(([name, input]) => {
         it(name, () => {
-            expect(html(input)).toMatchSnapshot();
+            expect(html(input, {enableMarkdownAttrs})).toMatchSnapshot();
         });
     });
 });


### PR DESCRIPTION
## Description

See diplodoc-platform/diplodoc#45

Added `enableMarkdownAttrs` option to transformer. It allows to disable `markdown-it-attrs` plugin. Default value is `enableMarkdownAttrs=true`, so current behavior is not changed.