### PR TITLE
feat(styles): added flexible customization of indents in lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ MIT
 - `--yfm-color-border`
 - `--yfm-color-accent`
 - `--yfm-tab-size`
+- `--yfm-text-block-margin-block`
 
 **code**
 
@@ -138,3 +139,9 @@ MIT
 
 - `--yfm-file-icon`
 - `--yfm-file-icon-color`
+
+**list**
+
+- `--yfm-list-item-margin-block`
+- `--yfm-list-text-margin-block`
+- `--yfm-list-text-last-margin-block`

--- a/README.ru.md
+++ b/README.ru.md
@@ -88,6 +88,7 @@ MIT
 - `--yfm-color-border`
 - `--yfm-color-accent`
 - `--yfm-tab-size`
+- `--yfm-text-block-margin-block`
 
 **code**
 
@@ -138,3 +139,9 @@ MIT
 
 - `--yfm-file-icon`
 - `--yfm-file-icon-color`
+
+**list**
+
+- `--yfm-list-item-margin-block`
+- `--yfm-list-text-margin-block`
+- `--yfm-list-text-last-margin-block`

--- a/playground/scripts/configs.mjs
+++ b/playground/scripts/configs.mjs
@@ -28,7 +28,6 @@ const configuredSassPlugin = sassPlugin({
                 stage: 0,
                 features: {
                     'logical-properties-and-values': false,
-                    'custom-properties': false,
                 },
             }),
         ]).process(source, config);

--- a/playground/scripts/configs.mjs
+++ b/playground/scripts/configs.mjs
@@ -24,7 +24,13 @@ const configuredSassPlugin = sassPlugin({
 
         const res = await postcss([
             autoprefixer({cascade: false}),
-            postcssPresetEnv({stage: 0}),
+            postcssPresetEnv({
+                stage: 0,
+                features: {
+                    'logical-properties-and-values': false,
+                    'custom-properties': false,
+                },
+            }),
         ]).process(source, config);
 
         return res.css;

--- a/scripts/package-build-configs.mjs
+++ b/scripts/package-build-configs.mjs
@@ -31,7 +31,13 @@ const plugins = [
         async transform(source) {
             const {css} = await postcss([
                 autoprefixer({cascade: false}),
-                postcssPresetEnv({stage: 0}),
+                postcssPresetEnv({
+                    stage: 0,
+                    features: {
+                        'logical-properties-and-values': false,
+                        'custom-properties': false,
+                    },
+                }),
             ]).process(source, {from: undefined});
 
             return css;

--- a/scripts/package-build-configs.mjs
+++ b/scripts/package-build-configs.mjs
@@ -35,7 +35,6 @@ const plugins = [
                     stage: 0,
                     features: {
                         'logical-properties-and-values': false,
-                        'custom-properties': false,
                     },
                 }),
             ]).process(source, {from: undefined});

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -14,11 +14,9 @@
 }
 
 $text-block-margin: 0 0 15px;
-$list-item-margin-top: 0.33em;
-$list-item-text-margin-top: 15px;
-$list-item-text-margin-bottom: 0;
-$list-item-last-text-margin-top: 15px;
-$list-item-last-text-margin-bottom: 0;
+$list-margin: 0.33em 0 0 0;
+$list-text-margin: 15px 0 0 0;
+$list-last-text-margin: 15px 0 0 0;
 
 .yfm {
     @include private-brand();
@@ -340,22 +338,17 @@ $list-item-last-text-margin-bottom: 0;
     }
 
     li + li {
-        margin-top: var(--yfm-list-item-margin-top, #{$list-item-margin-top});
+        margin: var(--yfm-list-margin, #{$list-margin});
     }
 
     li p,
     li blockquote {
-        margin-top: var(--yfm-list-item-text-margin-top, #{$list-item-text-margin-top});
-        margin-bottom: var(--yfm-list-item-text-margin-bottom, #{$list-item-text-margin-bottom});
+        margin: var(--yfm-list-text-margin, #{$list-text-margin});
     }
 
     li > p:last-child,
     li > blockquote:last-child {
-        margin-top: var(--yfm-list-item-last-text-margin-top, #{$list-item-last-text-margin-top});
-        margin-bottom: var(
-            --yfm-list-item-last-text-margin-bottom,
-            #{$list-item-last-text-margin-bottom}
-        );
+        margin: var(--yfm-list-last-text-margin, #{$list-last-text-margin});
     }
 
     code {

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -13,6 +13,13 @@
     }
 }
 
+$text-block-margin: 0 0 15px;
+$list-item-margin-top: 0.33em;
+$list-item-text-margin-top: 15px;
+$list-item-text-margin-bottom: 0;
+$list-item-last-text-margin-top: 15px;
+$list-item-last-text-margin-bottom: 0;
+
 .yfm {
     @include private-brand();
     @include brand();
@@ -135,7 +142,7 @@
     dl,
     table,
     pre {
-        margin: 0 0 15px;
+        margin: var(--yfm-text-block-margin, #{$text-block-margin});
     }
 
     ul,
@@ -333,12 +340,22 @@
     }
 
     li + li {
-        margin-top: 0.33em;
+        margin-top: var(--yfm-list-item-margin-top, #{$list-item-margin-top});
     }
 
     li p,
     li blockquote {
-        margin-top: 15px;
+        margin-top: var(--yfm-list-item-text-margin-top, #{$list-item-text-margin-top});
+        margin-bottom: var(--yfm-list-item-text-margin-bottom, #{$list-item-text-margin-bottom});
+    }
+
+    li > p:last-child,
+    li > blockquote:last-child {
+        margin-top: var(--yfm-list-item-last-text-margin-top, #{$list-item-last-text-margin-top});
+        margin-bottom: var(
+            --yfm-list-item-last-text-margin-bottom,
+            #{$list-item-last-text-margin-bottom}
+        );
     }
 
     code {

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -13,11 +13,6 @@
     }
 }
 
-$text-block-margin: 0 0 15px;
-$list-margin: 0.33em 0 0 0;
-$list-text-margin: 15px 0 0 0;
-$list-last-text-margin: 15px 0 0 0;
-
 .yfm {
     @include private-brand();
     @include brand();
@@ -140,7 +135,7 @@ $list-last-text-margin: 15px 0 0 0;
     dl,
     table,
     pre {
-        margin: var(--yfm-text-block-margin, #{$text-block-margin});
+        margin-block: var(--yfm-text-block-margin-block, 0 15px);
     }
 
     ul,
@@ -338,17 +333,17 @@ $list-last-text-margin: 15px 0 0 0;
     }
 
     li + li {
-        margin: var(--yfm-list-margin, #{$list-margin});
+        margin-block: var(--yfm-list-item-margin-block, 0.33em 0);
     }
 
     li p,
     li blockquote {
-        margin: var(--yfm-list-text-margin, #{$list-text-margin});
+        margin-block: var(--yfm-list-text-margin-block, 15px);
     }
 
     li > p:last-child,
     li > blockquote:last-child {
-        margin: var(--yfm-list-last-text-margin, #{$list-last-text-margin});
+        margin-block: var(--yfm-list-text-last-margin-block, 15px);
     }
 
     code {


### PR DESCRIPTION
This PR modifies `src/scss/_common.scss` to add CSS variables, enabling customizable margins for consistent Markdown list styling.

### PostCSS settings
The build was updated in `postcssPresetEnv` to use this configuration:

```javascript
postcssPresetEnv({
    stage: 0,
    features: {
        'logical-properties-and-values': false,
    },
}),
```

This disables logical properties processing (see [postcss-logical](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-logical#readme)) to preserve the original variable values.

### New CSS Variables
The table below lists the four new CSS variables, their purposes, and default values:

| Variable Name                    | Purpose                                                                 | Default Value |
|----------------------------------|-------------------------------------------------------------------------|---------------|
| `--yfm-text-block-margin-block`  | Sets vertical margins for text blocks (e.g., p, blockquote, ul, ol, dl, table, pre) | 0 15px        |
| `--yfm-list-item-margin-block`   | Defines vertical margins between list items (li + li)                  | 0.33em 0      |
| `--yfm-list-text-margin-block`   | Controls vertical margins for text elements (p, blockquote) within list items | 15px          |
| `--yfm-list-text-last-margin-block` | Adjusts vertical margins for the last text element (p, blockquote) in a list item | 15px       |

### Customization Example
These variables can be overridden in CSS for flexibility. It ensures uniform rendering and removes the bottom margin of the last paragraph in list items. Fixes #649

```css
:root {
    --yfm-text-block-margin-block: 15px 0;
    --yfm-list-text-last-margin-block: 0;
}
```

#### Before
<img width="1043" alt="default-lists" src="https://github.com/user-attachments/assets/93d0d818-5dde-4baf-a8f7-4b1e3aaff2c8" />

#### After
<img width="1038" alt="consistent-lists" src="https://github.com/user-attachments/assets/63ed5ff2-62dc-4afb-a28a-7b2c9cc9598f" />
