### PR TITLE
fix: added export for sanitize

### DIFF
--- a/src/transform/sanitize.ts
+++ b/src/transform/sanitize.ts
@@ -602,7 +602,7 @@ function sanitizeStyles(html: string, options: SanitizeOptions) {
     return styles + content;
 }
 
-export default function sanitize(
+export function sanitize(
     html: string,
     options?: SanitizeOptions,
     additionalOptions?: SanitizeOptions,
@@ -622,3 +622,5 @@ export default function sanitize(
 
     return sanitizeHtml(modifiedHtml, sanitizeOptions);
 }
+
+export default sanitize;


### PR DESCRIPTION
## Description

Added named `sanitize` function export alongside the default export for greater flexibility. Can be useful with ESM packages when Babel mishandles `default`, improving stability.