### PR TITLE
Remedy an issue where list markers would not get properly styled in some scenarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@diplodoc/cut-extension": "^0.7.2",
         "@diplodoc/file-extension": "^0.2.1",
-        "@diplodoc/tabs-extension": "^3.5.1",
+        "@diplodoc/tabs-extension": "^3.6.1",
         "chalk": "^4.1.2",
         "cheerio": "^1.0.0",
         "css": "^3.0.0",
@@ -3143,12 +3143,11 @@
       }
     },
     "node_modules/@diplodoc/tabs-extension": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@diplodoc/tabs-extension/-/tabs-extension-3.5.1.tgz",
-      "integrity": "sha512-YfxEiSq6S0E4XBmdgcTrV9Zh6LWjYKi5CixWzfe2NZt7OqT6WqcEXt4q9wSmtDMzlZf5pVYbl+y9+swVWqf9yQ==",
-      "license": "MIT",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@diplodoc/tabs-extension/-/tabs-extension-3.6.1.tgz",
+      "integrity": "sha512-ju3i+YD+bCSSHpS3FBveu+amtoRaJgXxf49p4wi2Mbs1OCWq1f+HsZL3ymD6EyWd6a2P92+SODqfk7oq3flybA==",
       "peerDependencies": {
-        "react": "^16.8.0  || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0  || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "react": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@diplodoc/cut-extension": "^0.7.2",
     "@diplodoc/file-extension": "^0.2.1",
-    "@diplodoc/tabs-extension": "^3.5.1",
+    "@diplodoc/tabs-extension": "^3.6.1",
     "chalk": "^4.1.2",
     "cheerio": "^1.0.0",
     "css": "^3.0.0",

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -302,28 +302,20 @@
         margin-bottom: 0;
     }
 
-    ol {
-        counter-reset: list;
+    ol > li {
+        &::marker {
+            content: counter(list-item) '. ';
+        }
 
-        & > li {
-            position: relative;
-            counter-increment: list;
+        & > ol > li::marker {
+            content: counters(list-item, '.') '. ';
         }
     }
 
-    ol > li > ol > li::marker {
-        content: counters(list, '.') '. ';
-    }
-
-    :not(ol > li) > ol > li::marker {
-        content: counter(list) '. ';
-    }
-
-    &.yfm_no-list-reset ol {
-        counter-reset: unset;
-
+    &.yfm_no-list-reset ol,
+    ol.yfm_no-list-reset {
         // No direct ancestor (>) combinator to preserve legacy behavior
-        & li::marker {
+        & > li::marker {
             content: unset;
         }
     }


### PR DESCRIPTION
`marker`s would not get affected by styles for lists that are direct descendants of the element bearing the `yfm` class.

This PR also introduces the use of the stock/native `list-item` counter instead of the ad-hoc `list` one. See https://www.w3.org/TR/css-lists-3/#list-item-counter for details.