### PR TITLE
fix(styles): fixed inline margins in text blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ MIT
 - `--yfm-color-accent`
 - `--yfm-tab-size`
 - `--yfm-text-block-margin-block`
+- `--yfm-text-block-margin-inline`
 
 **code**
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -89,6 +89,7 @@ MIT
 - `--yfm-color-accent`
 - `--yfm-tab-size`
 - `--yfm-text-block-margin-block`
+- `--yfm-text-block-margin-inline`
 
 **code**
 

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -136,6 +136,7 @@
     table,
     pre {
         margin-block: var(--yfm-text-block-margin-block, 0 15px);
+        margin-inline: var(--yfm-text-block-margin-inline, 0);
     }
 
     ul,


### PR DESCRIPTION
This PR fixes vertical margin issues in `blockquote` and other text blocks.

#### Changes:
1. Original styles (`margin: 0 0 15px`) were replaced with `margin-block: var(--yfm-text-block-margin-block, 0 15px)` (see [PR #648](https://github.com/diplodoc-platform/transform/pull/648)).
2. Missed that `blockquote` margins were reset; added `margin-inline: var(--yfm-text-block-margin-inline, 0)` to fix it.

#### Before and After
**Before**: Wide spacing in `blockquote`.  
<img width="687" alt="Screenshot 2025-03-06 at 12 05 55" src="https://github.com/user-attachments/assets/8e0f8d56-bc78-47b4-8506-6723525e01fa" />


**After**: Consistent vertical margins restored.
<img width="643" alt="Screenshot 2025-03-06 at 12 06 05" src="https://github.com/user-attachments/assets/abcc7c9f-6e96-46d4-92fd-21d8635e7609" />
