### PR TITLE
List counter containment

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -2,6 +2,7 @@
 
 @import 'private';
 @import 'brand';
+@import 'lists';
 
 @mixin removeMarginForEdgeChildren {
     & > *:first-child {
@@ -301,24 +302,6 @@
     ol ul {
         margin-top: 0;
         margin-bottom: 0;
-    }
-
-    ol > li {
-        &::marker {
-            content: counter(list-item) '. ';
-        }
-
-        & > ol > li::marker {
-            content: counters(list-item, '.') '. ';
-        }
-    }
-
-    &.yfm_no-list-reset ol,
-    ol.yfm_no-list-reset {
-        // No direct ancestor (>) combinator to preserve legacy behavior
-        & > li::marker {
-            content: unset;
-        }
     }
 
     li {

--- a/src/scss/_lists.scss
+++ b/src/scss/_lists.scss
@@ -1,0 +1,71 @@
+@use 'sass:list';
+@use 'sass:string';
+
+@function get-counter-ident($depth) {
+    $ident: hier-list-item;
+
+    @for $i from 0 to $depth {
+        $ident: sub-#{$ident};
+    }
+
+    @return $ident;
+}
+
+@function get-selector($depth) {
+    $selector: ol;
+
+    @for $i from 0 to $depth {
+        $selector: '#{$selector} > li > ol';
+    }
+
+    @return $selector;
+}
+
+@function get-marker-content($idents) {
+    $length: list.length($idents);
+    $content: '';
+
+    @for $i from 1 through $length {
+        @if $i > 1 {
+            $content: '#{$content} "."';
+        }
+
+        $content: '#{$content} counter(#{list.nth($idents, $i)})';
+    }
+
+    @return #{$content} '. ';
+}
+
+@mixin hier-list($max-depth) {
+    $ident-path: ();
+
+    @for $i from 0 through $max-depth {
+        $ident: get-counter-ident($i);
+        $ident-path: list.append($ident-path, $ident);
+
+        & #{get-selector($i)} {
+            --hier-list-start: 0;
+            counter-reset: #{$ident} var(--hier-list-start);
+
+            & > li {
+                counter-increment: $ident;
+
+                &::marker {
+                    content: get-marker-content($ident-path);
+                }
+            }
+        }
+    }
+}
+
+.yfm {
+    @include hier-list(5);
+
+    &.yfm_no-list-reset ol,
+    ol.yfm_no-list-reset {
+        // No direct ancestor (>) combinator to preserve legacy behavior
+        & > li::marker {
+            content: unset;
+        }
+    }
+}

--- a/src/transform/md.ts
+++ b/src/transform/md.ts
@@ -11,6 +11,7 @@ import makeHighlight from './highlight';
 import extractTitle from './title';
 import getHeadings from './headings';
 import sanitizeHtml from './sanitize';
+import {olAttrConversion} from './plugins/ol-attr-conversion';
 
 function initMarkdownIt(options: OptionsType) {
     const {
@@ -98,6 +99,7 @@ function initPlugins(md: MarkdownIt, options: OptionsType, pluginOptions: Markdo
 
     // Need for ids of headers
     md.use(attrs, {leftDelimiter, rightDelimiter});
+    md.use(olAttrConversion);
 
     plugins.forEach((plugin) => md.use(plugin, pluginOptions));
 

--- a/src/transform/plugins/ol-attr-conversion.ts
+++ b/src/transform/plugins/ol-attr-conversion.ts
@@ -1,0 +1,21 @@
+import {MarkdownItPluginCb} from '../typings';
+
+const cssWhitelist = {
+    '--hier-list-start': true,
+};
+
+export const olAttrConversion: MarkdownItPluginCb = (md) => {
+    md.core.ruler.after('block', 'olAttrs', (state) => {
+        state.tokens.forEach((token) => {
+            const maybeStart = token.attrGet('start');
+
+            if (token.type === 'ordered_list_open' && maybeStart) {
+                token.attrSet('style', `--hier-list-start: ${Number(maybeStart) - 1};`);
+            }
+        });
+
+        state.env.additionalOptionsCssWhiteList ||= {};
+
+        Object.assign(state.env.additionalOptionsCssWhiteList, cssWhitelist);
+    });
+};


### PR DESCRIPTION
Context:

https://www.w3.org/TR/css-lists-3/#auto-numbering
https://drafts.csswg.org/css-contain-2/#containment-style

Unfortunately, it's just not possible to style list markers appropriately using just a single CSS counter (preferably `list-item`), since counters are inherited, and it will always break no matter what you try to do in cases like this:

```
1. List item
2. List item 2
  1. Sublist item 1

  {% note info %}

   1. Independent list item 1
     1. Independent sublist item 1
  
  {% endnote %}
```

Containment also doesn't work as expected. Notably, adding a `ol { contain: style; }` rule for top-level lists does help in Firefox, but Firefox's behaviour in that scenario is not spec-compliant. Chrome works as spec instructs, resulting in weirdness like `0.2.0.1.1` in case of `Independent sublist item 1`.

Sensible solutions would be:

1. Use a different counters for lists in every block element (i.e. tab pages, notes, cuts, etc.) — a little too much variance for my liking
2. Hardcode a max depth, up to which a list would just use different counters for each level, leveraging the fact that `counter()` notation only cares about the counters on a single level of nesting (in contrast, `counters()` cares about the whole flattened tree).

I went with the 2nd one. This PR consists of an SCSS mixin that generates the styles for nested lists up to a certain depth, and a markdown-it plugin which appends a `style` attribute to a list token if it has an existing `start` attribute. This is to facilitate behaviour in cases similar to the ones below:

<img width="987" alt="изображение" src="https://github.com/user-attachments/assets/8fd27663-ae78-4ac5-93bb-84ed64afa16a" />
<img width="1204" alt="изображение" src="https://github.com/user-attachments/assets/860923ee-f78c-4b56-8447-2096a99dae46" />
