### PR TITLE
fix(styles): added max-height for img and svg

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -100,6 +100,7 @@
     svg {
         box-sizing: content-box;
         max-width: 100%;
+        max-height: fit-content;
         border: none;
         vertical-align: middle;
 


### PR DESCRIPTION

## Description

Added `max-height: fit-content` to `img` and `svg` elements to ensure they do not exceed their natural size and do not cause layout shifts. This prevents images from overflowing their containers when resized, maintaining a consistent layout and avoiding unwanted whitespace issues.

## Example
In a table layout, images with defined width and height could introduce unwanted empty spaces, breaking the expected structure.

```md
#|
||

Image

|

Text

||
||

![ddos-index-cover-mini](https://storage.yandexcloud.net/diplodoc-www-assets/pages/index-diplodoc/ddos-index-cover-mini.png =464x464)

|

simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.

||
|#
```

#### Before
<img width="602" alt="image-with-white-spaces" src="https://github.com/user-attachments/assets/078d33f8-b69b-41cc-a17d-6d950db06d30" />



#### After
<img width="605" alt="normal-image" src="https://github.com/user-attachments/assets/7c3e55f1-ebe4-4d29-8abe-d1e851d18f08" />

