### PR TITLE
feat(styles): updated list margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,4 +145,4 @@ MIT
 
 - `--yfm-list-item-margin-block`
 - `--yfm-list-text-margin-block`
-- `--yfm-list-text-last-margin-block`
+- `--yfm-list-text-only-margin-block`

--- a/README.ru.md
+++ b/README.ru.md
@@ -145,4 +145,4 @@ MIT
 
 - `--yfm-list-item-margin-block`
 - `--yfm-list-text-margin-block`
-- `--yfm-list-text-last-margin-block`
+- `--yfm-list-text-only-margin-block`

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -313,14 +313,23 @@
         margin-block: var(--yfm-list-item-margin-block, 0.33em 0);
     }
 
-    li p,
-    li blockquote {
-        margin-block: var(--yfm-list-text-margin-block, 15px);
-    }
+    li {
+        p,
+        blockquote {
+            margin-block: var(--yfm-list-text-margin-block, 0 15px);
+        }
 
-    li > p:last-child,
-    li > blockquote:last-child {
-        margin-block: var(--yfm-list-text-last-margin-block, 15px);
+        > p:only-child,
+        > blockquote:only-child {
+            margin-block: var(--yfm-list-text-only-margin-block, 0);
+        }
+
+        @supports selector(:has(br)) {
+            > p:only-child:has(br),
+            > blockquote:only-child:has(br) {
+                margin-block: var(--yfm-list-text-margin-block, 0 15px);
+            }
+        }
     }
 
     code {


### PR DESCRIPTION
Changes have been made to ensure consistent spacing in simple lists (see case 1 and 2 in example) during rendering without affecting other cases. See also #648

**Details:**

1. A CSS variable has been renamed to improve semantics and readability.
2. The `:has` pseudo-class has been applied to achieve the desired spacing behavior, as this cannot be solved with CSS without `:has` for all cases in `before/after` (case 4 and 5). While there were previous concerns about its performance, modern browsers have optimized it significantly. [For example](https://webkit.org/blog/13096/css-has-pseudo-class/).

#### Before
<img width="832" alt="has-diff" src="https://github.com/user-attachments/assets/6b0e4954-ee61-4ce9-8024-752e438eadd4" />

#### After
<img width="830" alt="no-diff" src="https://github.com/user-attachments/assets/20c42c72-9cf4-4699-8df2-7bd6a2b84c80" />

#### Example markup
```md
1. 11
2. 22

---

1. 11

2. 22

---

1. 11
   some text
2. 22

---

1. 11
   some text

2. 22

---

1. 11
   some text

   more
2. 22


```