### PR TITLE
fix(notes): added default lang parameter in notes

### DIFF
--- a/src/transform/plugins/notes/index.ts
+++ b/src/transform/plugins/notes/index.ts
@@ -37,7 +37,7 @@ function matchWrongNotes(tokens: Token[], i: number) {
 const findCloseTokenIdx = closeTokenFactory('Note', matchOpenToken, matchCloseToken);
 
 // @ts-ignore
-const index: MarkdownItPluginCb = (md, {lang, notesAutotitle, path: optPath, log}) => {
+const index: MarkdownItPluginCb = (md, {lang = 'en', notesAutotitle, path: optPath, log}) => {
     notesAutotitle = typeof notesAutotitle === 'boolean' ? notesAutotitle : true;
 
     const plugin = (state: StateCore) => {


### PR DESCRIPTION
Added `lang = 'en'` default parameter to the index function to prevent markdown-editor crash when using a newer transform version without passing lang.
