### PR TITLE
docs: fix frontmatter.ts typo

### DIFF
--- a/src/transform/frontmatter.ts
+++ b/src/transform/frontmatter.ts
@@ -23,7 +23,7 @@ const escapeLiquid = (content: string): string =>
 
 /**
  * Inverse of a workaround defined above.
- * @see `escapeLiquidSubstitutionSyntax`
+ * @see `escapeLiquid`
  * @param escapedContent Input string with `{}` escaped with backslashes
  * @returns Unescaped string
  */


### PR DESCRIPTION
В src/transform/frontmatter.ts в описании функции unescapeLiquid указан @see escapeLiquidSubstitutionSyntax, но такой функции нет (правильное название – escapeLiquid)
