### PR TITLE
Fix Issues with Local Image Links Containing Cyrillic Characters

### DIFF
--- a/src/transform/plugins/changelog/index.ts
+++ b/src/transform/plugins/changelog/index.ts
@@ -6,6 +6,8 @@ import type {MarkdownItPluginCb} from '../typings';
 import {bold} from 'chalk';
 import yaml from 'js-yaml';
 
+import {getSrcTokenAttr} from '../../utils';
+
 interface Options {
     extractChangelogs?: boolean;
 }
@@ -85,7 +87,7 @@ function parseBody(tokens: Token[], state: StateCore) {
                 alt = md.renderer.renderInlineAsText(imageToken.children, md.options, env);
             }
             image = {
-                src: imageToken.attrGet('src'),
+                src: getSrcTokenAttr(imageToken),
                 alt,
                 ratio,
             };

--- a/src/transform/plugins/images/collect.ts
+++ b/src/transform/plugins/images/collect.ts
@@ -3,7 +3,7 @@ import type {MarkdownItPluginOpts} from '../typings';
 import MarkdownIt from 'markdown-it';
 import {relative} from 'path';
 
-import {isLocalUrl} from '../../utils';
+import {getSrcTokenAttr, isLocalUrl} from '../../utils';
 import {resolveRelativePath} from '../../utilsFS';
 import deflist from '../deflist';
 import imsize from '../imsize';
@@ -33,7 +33,7 @@ const collect = (input: string, options: Options) => {
                 return;
             }
 
-            const src = childToken.attrGet('src') || '';
+            const src = getSrcTokenAttr(childToken);
 
             if (!isLocalUrl(src)) {
                 return;

--- a/src/transform/plugins/images/index.ts
+++ b/src/transform/plugins/images/index.ts
@@ -8,7 +8,7 @@ import {optimize} from 'svgo';
 import {readFileSync} from 'fs';
 
 import {isFileExists, resolveRelativePath} from '../../utilsFS';
-import {isExternalHref, isLocalUrl} from '../../utils';
+import {getSrcTokenAttr, isExternalHref, isLocalUrl} from '../../utils';
 
 interface ImageOpts extends MarkdownItPluginOpts {
     assetsPublicPath: string;
@@ -20,7 +20,7 @@ function replaceImageSrc(
     state: StateCore,
     {assetsPublicPath = sep, root = '', path: optsPath, log}: ImageOpts,
 ) {
-    const src = token.attrGet('src') || '';
+    const src = getSrcTokenAttr(token);
     const currentPath = state.env.path || optsPath;
 
     if (!isLocalUrl(src)) {
@@ -57,7 +57,7 @@ function convertSvg(
     {path: optsPath, log, notFoundCb, root}: SVGOpts,
 ) {
     const currentPath = state.env.path || optsPath;
-    const path = resolveRelativePath(currentPath, token.attrGet('src') || '');
+    const path = resolveRelativePath(currentPath, getSrcTokenAttr(token));
 
     try {
         const raw = readFileSync(path).toString();
@@ -114,7 +114,7 @@ const index: MarkdownItPluginCb<Opts> = (md, opts) => {
                         return;
                     }
 
-                    const imgSrc = childrenTokens[j].attrGet('src') || '';
+                    const imgSrc = getSrcTokenAttr(childrenTokens[j]);
                     const shouldInlineSvg = opts.inlineSvg !== false && !isExternalHref(imgSrc);
 
                     if (imgSrc.endsWith('.svg') && shouldInlineSvg) {

--- a/src/transform/utils.ts
+++ b/src/transform/utils.ts
@@ -92,6 +92,16 @@ export function getHrefTokenAttr(token: Token) {
     return href;
 }
 
+export function getSrcTokenAttr(token: Token) {
+    let src = token.attrGet('src') || '';
+    try {
+        // decodeURI can throw an error https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError
+        src = decodeURI(src);
+    } catch (e) {}
+
+    return src;
+}
+
 export const PAGE_LINK_REGEXP = /\.(md|ya?ml)$/i;
 
 export function defaultTransformLink(href: string) {

--- a/test/images.test.ts
+++ b/test/images.test.ts
@@ -1,0 +1,34 @@
+import MarkdownIt from 'markdown-it';
+
+import transform from '../src/transform';
+import images from '../src/transform/plugins/images';
+import {log} from '../src/transform/log';
+
+describe('Images plugin', () => {
+    beforeEach(() => {
+        log.clear();
+    });
+
+    test('markdown-it encodes image src', () => {
+        const md = new MarkdownIt();
+        const tokens = md.parse('![тест](русские-символы.png)', {});
+        const src = tokens[1].children?.[0].attrGet('src');
+
+        expect(src).toBe(encodeURI('русские-символы.png'));
+    });
+
+    test('should handle external image links with cyrillic characters', () => {
+        const input = '![тест](https://example.com/русские-символы.png)';
+
+        const {
+            result: {html},
+        } = transform(input, {
+            plugins: [images],
+        });
+
+        expect(html).toEqual(
+            '<p><img src="https://example.com/%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B5-%D1%81%D0%B8%D0%BC%D0%B2%D0%BE%D0%BB%D1%8B.png" alt="тест" /></p>\n',
+        );
+        expect(log.isEmpty()).toEqual(true);
+    });
+});


### PR DESCRIPTION
## Summary
- decode src attributes in images
- support Cyrillic image paths in changelog and images collect
- add regression tests for Cyrillic image src
- test external image links with Cyrillic characters

Fixes https://github.com/diplodoc-platform/transform/issues/573