### PR TITLE
fix: remove duplication and not actively maintained cheerio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@diplodoc/tabs-extension": "^3.7.2",
         "@diplodoc/utils": "^2.1.0",
         "chalk": "^4.1.2",
-        "cheerio": "^1.0.0",
         "css": "^3.0.0",
         "cssfilter": "0.0.10",
         "get-root-node-polyfill": "1.0.0",
@@ -28,6 +27,7 @@
         "markdown-it-sup": "1.0.0",
         "markdownlint": "^0.32.1",
         "markdownlint-rule-helpers": "0.17.2",
+        "parse5": "^7.1.2",
         "quick-lru": "^5.1.1",
         "sanitize-html": "^2.11.0",
         "slugify": "1.6.6",
@@ -5645,66 +5645,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cheerio": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
-      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.1.0",
-        "encoding-sniffer": "^0.2.0",
-        "htmlparser2": "^9.1.0",
-        "parse5": "^7.1.2",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0",
-        "parse5-parser-stream": "^7.1.2",
-        "undici": "^6.19.5",
-        "whatwg-mimetype": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18.17"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cheerio/node_modules/htmlparser2": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.1.0",
-        "entities": "^4.5.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -6631,19 +6571,6 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encoding-sniffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.0.tgz",
-      "integrity": "sha512-ju7Wq1kg04I3HtiYIOrUrdfdDvkyO9s5XM8QAj/bN61Yo/Vb4vgJxy5vi4Yxk01gWHbrofpPtpxM8bKger9jhg==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.17.1",
@@ -8263,6 +8190,7 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -8293,18 +8221,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -11290,30 +11206,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-      "dependencies": {
-        "domhandler": "^5.0.2",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5-parser-stream": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12897,12 +12789,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
     },
     "node_modules/sanitize-html": {
       "version": "2.12.1",
@@ -14680,15 +14566,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
-      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -14821,27 +14698,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@diplodoc/tabs-extension": "^3.7.2",
     "@diplodoc/utils": "^2.1.0",
     "chalk": "^4.1.2",
-    "cheerio": "^1.0.0",
+    "parse5": "^7.1.2",
     "css": "^3.0.0",
     "cssfilter": "0.0.10",
     "get-root-node-polyfill": "1.0.0",

--- a/src/transform/sanitize.ts
+++ b/src/transform/sanitize.ts
@@ -1,10 +1,18 @@
 import type {Attributes, Tag} from 'sanitize-html';
 import type {CssWhiteList} from './typings';
+import type {
+    Document as Parse5Document,
+    Element as Parse5Element,
+    Node as Parse5Node,
+    ParentNode as Parse5ParentNode,
+    Template as Parse5Template,
+    TextNode as Parse5TextNode,
+} from 'parse5/dist/tree-adapters/default';
 
 import sanitizeHtml from 'sanitize-html';
 // @ts-ignore
 import cssfilter from 'cssfilter';
-import * as cheerio from 'cheerio';
+import * as parse5 from 'parse5';
 import css from 'css';
 
 import log from './log';
@@ -562,11 +570,51 @@ export const defaultOptions: SanitizeOptions = {
     },
 };
 
-function sanitizeStyleTags(dom: cheerio.CheerioAPI, cssWhiteList: CssWhiteList) {
-    const styleTags = dom('style');
+function isElement(node: Parse5Node): node is Parse5Element {
+    return (node as Parse5Element).tagName !== undefined;
+}
 
-    styleTags.each((_index, element) => {
-        const styleText = dom(element).text();
+function traverse(node: Parse5Node, cb: (n: Parse5Node) => void) {
+    cb(node);
+    const parent = node as Parse5ParentNode;
+    if (parent.childNodes) {
+        for (const child of parent.childNodes) {
+            traverse(child, cb);
+        }
+    }
+    const template = node as Parse5Template;
+    if (template.content) {
+        traverse(template.content, cb);
+    }
+}
+
+function findElement(root: Parse5Document, tag: string): Parse5Element | null {
+    let found: Parse5Element | null = null;
+    traverse(root, (n) => {
+        if (!found && isElement(n) && n.tagName === tag) {
+            found = n;
+        }
+    });
+    return found;
+}
+
+function serializeInner(node: Parse5ParentNode): string {
+    return node.childNodes.map((child) => parse5.serializeOuter(child)).join('');
+}
+
+function sanitizeStyleTags(root: Parse5Document, cssWhiteList: CssWhiteList) {
+    const styleTags: Parse5Element[] = [];
+    traverse(root, (node) => {
+        if (isElement(node) && node.tagName === 'style') {
+            styleTags.push(node);
+        }
+    });
+
+    styleTags.forEach((element) => {
+        const styleText = element.childNodes
+            .filter((n) => n.nodeName === '#text')
+            .map((n) => (n as Parse5TextNode).value)
+            .join('');
 
         try {
             const parsedCSS = css.parse(styleText);
@@ -606,9 +654,19 @@ function sanitizeStyleTags(dom: cheerio.CheerioAPI, cssWhiteList: CssWhiteList) 
                 });
             });
 
-            dom(element).text(css.stringify(parsedCSS));
+            element.childNodes = [
+                {
+                    nodeName: '#text',
+                    value: css.stringify(parsedCSS),
+                    parentNode: element,
+                } as Parse5TextNode,
+            ];
         } catch (error) {
-            dom(element).remove();
+            if (element.parentNode) {
+                element.parentNode.childNodes = element.parentNode.childNodes.filter(
+                    (n) => n !== element,
+                );
+            }
 
             const errorMessage = error instanceof Error ? error.message : `${error}`;
             log.info(errorMessage);
@@ -616,33 +674,38 @@ function sanitizeStyleTags(dom: cheerio.CheerioAPI, cssWhiteList: CssWhiteList) 
     });
 }
 
-function sanitizeStyleAttrs(dom: cheerio.CheerioAPI, cssWhiteList: CssWhiteList) {
+function sanitizeStyleAttrs(root: Parse5Document, cssWhiteList: CssWhiteList) {
     const options = {
         whiteList: cssWhiteList,
     };
     const cssSanitizer = new cssfilter.FilterCSS(options);
-
-    dom('*').each((_index, element) => {
-        const styleAttrValue = dom(element).attr('style');
-
-        if (!styleAttrValue) {
-            return;
+    traverse(root, (node) => {
+        if (isElement(node)) {
+            const styleAttr = node.attrs.find((a) => a.name === 'style');
+            if (!styleAttr) {
+                return;
+            }
+            styleAttr.value = cssSanitizer.process(styleAttr.value);
+            if (!styleAttr.value) {
+                node.attrs = node.attrs.filter((a) => a !== styleAttr);
+            }
         }
-
-        dom(element).attr('style', cssSanitizer.process(styleAttrValue));
     });
 }
 
 export function sanitizeStyles(html: string, options: SanitizeOptions) {
     const cssWhiteList = options.cssWhiteList || {};
 
-    const $ = cheerio.load(html);
+    const document = parse5.parse(html);
 
-    sanitizeStyleTags($, cssWhiteList);
-    sanitizeStyleAttrs($, cssWhiteList);
+    sanitizeStyleTags(document, cssWhiteList);
+    sanitizeStyleAttrs(document, cssWhiteList);
 
-    const styles = $('head').html() || '';
-    const content = $('body').html() || '';
+    const head = findElement(document, 'head');
+    const body = findElement(document, 'body');
+
+    const styles = head ? serializeInner(head) : '';
+    const content = body ? serializeInner(body) : '';
 
     return styles + content;
 }


### PR DESCRIPTION
## Summary
- switch sanitize utilities from cheerio to parse5
- traverse parse5 AST without CSS selectors
- adjust htmlparser2 dependency test

**Why remove cheerio?**
1) All stable releases of cheerio (1.0.0 and 1.1.0) depend on newer majors of htmlparser2 (9.x and 10.x respectively).
In contrast, sanitize-html—including its latest version 2.17.0—depends on htmlparser2 8.x.

Because there’s no stable cheerio version using htmlparser2 8.x, the only way to share a single htmlparser2 version without overrides is to use the release‑candidate cheerio 1.0.0-rc.12 currently present in package.json.

2) cheerio seems to be not actively maintained at the moment
https://github.com/cheeriojs/cheerio/issues/4068#issuecomment-2465863800

fixes https://github.com/diplodoc-platform/transform/issues/547
