### PR TITLE
feat: supported sticky header for multiline table

### DIFF
--- a/src/scss/_table.scss
+++ b/src/scss/_table.scss
@@ -59,5 +59,38 @@
         }
     }
 
+    &:not(:has(thead)) {
+        tbody > tr:first-child,
+        > tr:first-child {
+            position: sticky;
+            top: 0;
+            z-index: 2;
+
+            td,
+            th {
+                position: relative;
+                z-index: 0;
+            }
+
+            td::before,
+            th::before {
+                content: '';
+                background: var(--yfm-color-base);
+                position: absolute;
+                inset: 0;
+                z-index: -2;
+            }
+
+            td::after,
+            th::after {
+                content: '';
+                background: var(--yfm-color-table-row-background);
+                position: absolute;
+                inset: 0;
+                z-index: -1;
+            }
+        }
+    }
+
     max-height: 70vh;
 }


### PR DESCRIPTION
By analogy with simple tables, sticky header for multiline tables is supported