### PR TITLE
fix: disable prefix in svg classes

### DIFF
--- a/src/transform/plugins/images/index.ts
+++ b/src/transform/plugins/images/index.ts
@@ -48,7 +48,7 @@ interface SVGOpts extends MarkdownItPluginOpts {
 function prefix() {
     const value = Math.floor(Math.random() * 1e9);
 
-    return value.toString(16);
+    return 'rnd-' + value.toString(16);
 }
 
 function convertSvg(
@@ -67,6 +67,7 @@ function convertSvg(
                     name: 'prefixIds',
                     params: {
                         prefix: prefix(),
+                        prefixClassNames: false,
                     },
                 },
             ],


### PR DESCRIPTION
disable prefix in svg classes