### PR TITLE
fix: set max-height: none for .yfm mermaid svg

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -113,6 +113,10 @@
         }
     }
 
+    .mermaid svg[id*='mermaid'] {
+        max-height: none;
+    }
+
     img {
         object-fit: contain;
         background-color: var(--yfm-color-base);


### PR DESCRIPTION
#### В Safari mermaid диаграмма отображается мелко



<img width="928" height="179" alt="Screenshot 2025-08-06 at 14 18 25" src="https://github.com/user-attachments/assets/0ae9e7e3-5596-406f-9bbc-c355557e28bb" />

max-height: none - исправляет это, не ломает поведение в других браузерах (FF, Chrome, Yandex)
