### PR TITLE
fix(sanitize): prevent XSS via SVG animate values attribute

### DIFF
--- a/src/transform/sanitize.ts
+++ b/src/transform/sanitize.ts
@@ -554,6 +554,7 @@ export const defaultOptions: SanitizeOptions = {
         'xlink:href',
         'from',
         'to',
+        'values',
     ],
     allowVulnerableTags: true,
     parser: defaultParseOptions,

--- a/test/__snapshots__/xss.test.ts.snap
+++ b/test/__snapshots__/xss.test.ts.snap
@@ -236,6 +236,40 @@ exports[`XSS checks with disabled markdown-it-attrs You can EMBED SVG which can 
 </p>
 `;
 
+exports[`XSS checks with disabled markdown-it-attrs animate with values attribute 1`] = `
+<p>
+  <svg>
+    <animate xlink:href="#xss"
+             attributename="href"
+    >
+    </animate>
+    <a id="xss">
+      <text x="20"
+            y="20"
+      >
+        XSS
+      </text>
+    </a>
+  </svg>
+</p>
+`;
+
+exports[`XSS checks with disabled markdown-it-attrs animate with values attribute and data: scheme 1`] = `
+<p>
+  <svg>
+    <animate xlink:href="#x"
+             attributename="href"
+    >
+    </animate>
+    <a id="x">
+      <text>
+        Click
+      </text>
+    </a>
+  </svg>
+</p>
+`;
+
 exports[`XSS checks with disabled markdown-it-attrs body image 1`] = `""`;
 
 exports[`XSS checks with disabled markdown-it-attrs body tag 1`] = `""`;
@@ -582,6 +616,40 @@ exports[`XSS checks with enabled markdown-it-attrs XSS locator 2 1`] = `
 
 exports[`XSS checks with enabled markdown-it-attrs You can EMBED SVG which can contain your XSS vector 1`] = `
 <p>
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs animate with values attribute 1`] = `
+<p>
+  <svg>
+    <animate xlink:href="#xss"
+             attributename="href"
+    >
+    </animate>
+    <a id="xss">
+      <text x="20"
+            y="20"
+      >
+        XSS
+      </text>
+    </a>
+  </svg>
+</p>
+`;
+
+exports[`XSS checks with enabled markdown-it-attrs animate with values attribute and data: scheme 1`] = `
+<p>
+  <svg>
+    <animate xlink:href="#x"
+             attributename="href"
+    >
+    </animate>
+    <a id="x">
+      <text>
+        Click
+      </text>
+    </a>
+  </svg>
 </p>
 `;
 

--- a/test/xss.test.ts
+++ b/test/xss.test.ts
@@ -167,6 +167,14 @@ const ckecks = [
         'href animate from',
         `<div id="test"><svg><a xmlns:xlink="http://www.w3.org/1999/xlink" href="javascript:alert(document.domain)"><circle r="400"></circle><animate attributeName="href" begin="0" from="javascript:alert(document.domain)" to="&" /></a></div>`,
     ],
+    [
+        'animate with values attribute',
+        `<svg><animate xlink:href="#xss" attributeName="href" values="javascript:alert(1)"></animate><a id="xss"><text x="20" y="20">XSS</text></a></svg>`,
+    ],
+    [
+        'animate with values attribute and data: scheme',
+        `<svg><animate xlink:href="#x" attributeName="href" values="data:text/html,<script>alert(1)</script>"></animate><a id="x"><text>Click</text></a></svg>`,
+    ],
 ];
 
 describe.each([


### PR DESCRIPTION
Found that `values` attribute in SVG `<animate>` tags wasn't being checked for dangerous URL schemes like `javascript:` or `data:`. This could be exploited like this:

```svg
<svg>
  <animate xlink:href="#xss" attributeName="href" values="javascript:alert(1)" />
  <a id="xss"><text>Click</text></a>
</svg>
```

The issue is that `allowedSchemesAppliedToAttributes` already has `from` and `to` for animate elements, but `values` was missing.

### Changes

Added `values` to the list of attributes that get validated.
Now it works the same way as `href`, `from`, and `to` - extracts the scheme and blocks if it's not in the whitelist.
Regular animation values like `"0;1;0"` or `"red;green;blue"` work fine since they don't have a scheme prefix.
Only stuff like `javascript:`, `data:`, `vbscript:` gets filtered out.

### Tests

Added two test cases to xss.test.ts - one with `javascript:` and one with `data:` scheme.
Both get properly sanitized now (the `values` attribute is removed from the output).