### PR TITLE
feat(styles): add background for heading anchors

### DIFF
--- a/src/scss/_anchor.scss
+++ b/src/scss/_anchor.scss
@@ -21,6 +21,7 @@
 
         .yfm-anchor,
         .yfm-clipboard-anchor {
+            position: relative;
             display: inline-block;
             width: 24px;
             padding-right: 4px;
@@ -37,6 +38,11 @@
             }
 
             &::before {
+                padding: 0 4px;
+
+                border-radius: 3px;
+                background-color: var(--yfm-color-base);
+
                 content: '#';
                 opacity: 0;
             }


### PR DESCRIPTION
## Description

| Before | After |
|--------|--------|
| <img width="300" height="351" alt="image" src="https://github.com/user-attachments/assets/a224a9a4-c994-4b14-b5a8-7c5d612a0610" /> | <img width="300" height="351" alt="image" src="https://github.com/user-attachments/assets/51d91918-0e8b-45e5-9da7-aab3e7dd5179" /> | 
