### PR TITLE
Add line numbering for code blocks

### DIFF
--- a/src/scss/_code.scss
+++ b/src/scss/_code.scss
@@ -35,6 +35,16 @@
             code.wrap {
                 white-space: pre-wrap;
             }
+
+            .yfm-line-number {
+                display: inline-block;
+                min-width: 2ch;
+                padding-right: 1.5em;
+                text-align: right;
+                color: var(--yfm-color-code-line-numbers, var(--yfm-color-table-border, #ccc));
+                user-select: none;
+                -webkit-user-select: none;
+            }
         }
 
         .yfm-code-floating {

--- a/src/transform/plugins/code.ts
+++ b/src/transform/plugins/code.ts
@@ -158,6 +158,8 @@ type CodeOptions = {
     codeLineWrapping?: boolean;
 };
 
+const SHOW_LINE_NUMBERS_RE = /\s+showLineNumbers\b/g;
+
 const code: MarkdownItPluginCb<CodeOptions> = (md, opts) => {
     const lineWrapping = opts?.codeLineWrapping || false;
     const generateID = opts.generateID ?? globalGenerateID;
@@ -166,6 +168,10 @@ const code: MarkdownItPluginCb<CodeOptions> = (md, opts) => {
     md.renderer.rules.fence = function (tokens, idx, options, env, self) {
         const token = tokens[idx];
         const showLineNumbers = token.info.includes('showLineNumbers');
+
+        if (showLineNumbers) {
+            token.info = token.info.replace(SHOW_LINE_NUMBERS_RE, '');
+        }
 
         let superCode = superCodeRenderer?.(tokens, idx, options, env, self);
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request, before submitting, please read commit message formatting guidelines at https://www.conventionalcommits.org/en/v1.0.0/

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that the code is up-to-date with the `master` branch.
4. Include a description of the proposed changes and how to test them.

For Russian speaking contributors:
Перед отправкой PR-a, пожалуйста, прочтите гайды для разработчиков платформы Diplodoc : https://diplodoc.com/docs/ru/dev/
#xxxx" -->

## Description

<!-- Please include a summary of the changes. If it is feasible, it is worth attaching a screenshot or video of the changes. -->
Implemented line numbering for YFM code blocks.

Changes
1. src/transform/plugins/code.ts
Added regexp SHOW_LINE_NUMBERS_RE and cleared token.info from showLineNumbers .

2. src/scss/_code.scss
Added CSS styles for .yfm-line-number.

Related issue: #534

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
