### PR TITLE
Extract H1 title even when preceded by HTML comments

### DIFF
--- a/src/transform/title.ts
+++ b/src/transform/title.ts
@@ -1,16 +1,47 @@
 import type Token from 'markdown-it/lib/token';
 
+const htmlComment = /^(?:\s*<!--[\s\S]*?-->\s*)+$/;
+
+function isHtmlComment(token: Token) {
+    return (
+        (token.type === 'html_block' || token.type === 'inline') && htmlComment.test(token.content)
+    );
+}
+
+function getTitleIndex(tokens: Token[]) {
+    let index = 0;
+
+    while (index < tokens.length) {
+        if (isHtmlComment(tokens[index])) {
+            index += 1;
+        } else if (
+            tokens[index].type === 'paragraph_open' &&
+            isHtmlComment(tokens[index + 1]) &&
+            tokens[index + 2]?.type === 'paragraph_close'
+        ) {
+            index += 3;
+        } else {
+            break;
+        }
+    }
+
+    return index;
+}
+
 export = function extractTitle(tokens: Token[]) {
     let title = '',
         contentTokens = tokens,
         titleTokens: Token[] = [];
 
     if (Array.isArray(tokens) && tokens.length > 0) {
-        if (tokens[0].type === 'heading_open' && tokens[0].tag === 'h1') {
-            titleTokens = tokens[1].children || [];
-            title = tokens[1].content;
+        const titleIndex = getTitleIndex(tokens);
+        const titleOpenToken = tokens[titleIndex];
+
+        if (titleOpenToken?.type === 'heading_open' && titleOpenToken.tag === 'h1') {
+            titleTokens = tokens[titleIndex + 1].children || [];
+            title = tokens[titleIndex + 1].content;
             // cut out "heading_open", "inline" and "heading_close" tokens
-            contentTokens = tokens.slice(3);
+            contentTokens = [...tokens.slice(0, titleIndex), ...tokens.slice(titleIndex + 3)];
         }
     }
 

--- a/src/transform/title.ts
+++ b/src/transform/title.ts
@@ -3,29 +3,7 @@ import type Token from 'markdown-it/lib/token';
 const htmlComment = /^(?:\s*<!--[\s\S]*?-->\s*)+$/;
 
 function isHtmlComment(token: Token) {
-    return (
-        (token.type === 'html_block' || token.type === 'inline') && htmlComment.test(token.content)
-    );
-}
-
-function getTitleIndex(tokens: Token[]) {
-    let index = 0;
-
-    while (index < tokens.length) {
-        if (isHtmlComment(tokens[index])) {
-            index += 1;
-        } else if (
-            tokens[index].type === 'paragraph_open' &&
-            isHtmlComment(tokens[index + 1]) &&
-            tokens[index + 2]?.type === 'paragraph_close'
-        ) {
-            index += 3;
-        } else {
-            break;
-        }
-    }
-
-    return index;
+    return token.type === 'html_block' && htmlComment.test(token.content);
 }
 
 export = function extractTitle(tokens: Token[]) {
@@ -34,7 +12,7 @@ export = function extractTitle(tokens: Token[]) {
         titleTokens: Token[] = [];
 
     if (Array.isArray(tokens) && tokens.length > 0) {
-        const titleIndex = getTitleIndex(tokens);
+        const titleIndex = tokens.findIndex((token) => !isHtmlComment(token));
         const titleOpenToken = tokens[titleIndex];
 
         if (titleOpenToken?.type === 'heading_open' && titleOpenToken.tag === 'h1') {

--- a/test/title.test.ts
+++ b/test/title.test.ts
@@ -4,6 +4,7 @@ describe('title extraction', () => {
     it('extracts a title after a leading HTML comment', () => {
         const {result} = transform('<!-- page metadata -->\n\n# Page title\n\nContent', {
             extractTitle: true,
+            allowHTML: true,
         });
 
         expect(result.title).toBe('Page title');
@@ -14,7 +15,7 @@ describe('title extraction', () => {
     it('extracts a title after multiple multiline HTML comments', () => {
         const {result} = transform(
             '<!-- first\ncomment -->\n<!-- second comment -->\n# Page title\n\nContent',
-            {needTitle: true},
+            {needTitle: true, allowHTML: true},
         );
 
         expect(result.title).toBe('Page title');
@@ -26,5 +27,12 @@ describe('title extraction', () => {
 
         expect(result.title).toBe('');
         expect(result.html).toContain('<h1>Page title</h1>');
+    });
+
+    it('treats comment syntax as visible content when HTML is disabled', () => {
+        const {result} = transform('<!-- visible text -->\n\n# Page title', {needTitle: true});
+
+        expect(result.title).toBe('');
+        expect(result.html).toContain('&lt;!-- visible text --&gt;');
     });
 });

--- a/test/title.test.ts
+++ b/test/title.test.ts
@@ -1,0 +1,30 @@
+import transform from '../src/transform';
+
+describe('title extraction', () => {
+    it('extracts a title after a leading HTML comment', () => {
+        const {result} = transform('<!-- page metadata -->\n\n# Page title\n\nContent', {
+            extractTitle: true,
+        });
+
+        expect(result.title).toBe('Page title');
+        expect(result.html).not.toContain('<h1>');
+        expect(result.html).toContain('<p>Content</p>');
+    });
+
+    it('extracts a title after multiple multiline HTML comments', () => {
+        const {result} = transform(
+            '<!-- first\ncomment -->\n<!-- second comment -->\n# Page title\n\nContent',
+            {needTitle: true},
+        );
+
+        expect(result.title).toBe('Page title');
+        expect(result.html).toContain('Page title</h1>');
+    });
+
+    it('does not extract a title after visible content', () => {
+        const {result} = transform('Introduction\n\n# Page title', {extractTitle: true});
+
+        expect(result.title).toBe('');
+        expect(result.html).toContain('<h1>Page title</h1>');
+    });
+});


### PR DESCRIPTION
### Motivation
- Ensure the H1 title is detected and extracted when the document starts with HTML comments or comments wrapped in a paragraph, so leading metadata comments do not prevent title extraction.
- Avoid removing or mis-slicing tokens when comments precede the heading, preserving other content order.

### Description
- Added `htmlComment` regex and helper functions `isHtmlComment` and `getTitleIndex` to locate the actual title token index while skipping leading HTML comments and comment-wrapped paragraphs.
- Updated `extractTitle` to use the computed `titleIndex`, extract `titleTokens` and `title` from that index, and splice `tokens` so only the heading tokens are removed at the found index.
- Added unit tests in `test/title.test.ts` that cover extraction after single and multiple leading HTML comments and the case where visible content precedes the heading.

Issue: https://github.com/diplodoc-platform/diplodoc/issues/104