### PR TITLE
fix: add gallery-id attribute

### DIFF
--- a/src/transform/plugins/images/index.ts
+++ b/src/transform/plugins/images/index.ts
@@ -155,6 +155,11 @@ function collectDataAttrs(
             continue;
         }
 
+        if (key === 'gallery-id' && value !== '') {
+            result['data-gallery-id'] = value;
+            continue;
+        }
+
         const gallerySrc = resolveGallerySrcAttr(
             key,
             value,
@@ -173,6 +178,7 @@ function collectDataAttrs(
         if (
             key.startsWith('data-') &&
             key !== 'data-gallery-src' &&
+            (key !== 'data-gallery-id' || value !== '') &&
             (key !== 'data-gallery' || isGalleryValid(value))
         ) {
             result[key] = value;
@@ -182,10 +188,17 @@ function collectDataAttrs(
     image.attrs = image.attrs.filter(
         ([key, value]) =>
             key !== 'gallery' &&
+            key !== 'gallery-id' &&
             key !== 'gallery-src' &&
             (key !== 'data-gallery' || isGalleryValid(value)) &&
+            (key !== 'data-gallery-id' || value !== '') &&
             (key !== 'data-gallery-src' || value !== ''),
     );
+
+    if (result['data-gallery-id']) {
+        result['data-gallery'] = 'true';
+    }
+
     return result;
 }
 

--- a/src/transform/plugins/imsize/plugin.ts
+++ b/src/transform/plugins/imsize/plugin.ts
@@ -307,19 +307,26 @@ function isOwnAttr(key: string): boolean {
         key === 'height' ||
         key === 'inline' ||
         key === 'gallery' ||
+        key === 'gallery-id' ||
         key === 'gallery-src' ||
         key.startsWith('data-')
     );
 }
 
 function resolveDataAttr(key: string, value: string): [string, string] | null {
-    const isGalleryValid = value === 'true' || value === 'false';
+    if (key === 'gallery' || key === 'data-gallery') {
+        const isGalleryValid = value === 'true' || value === 'false';
 
-    if (key === 'gallery') return isGalleryValid ? ['data-gallery', value] : null;
-    if (key === 'data-gallery') return isGalleryValid ? [key, value] : null;
-    if (key === 'gallery-src') return value === '' ? null : ['data-gallery-src', value];
-    if (key.startsWith('data-')) return [key, value];
-    return null;
+        return isGalleryValid ? ['data-gallery', value] : null;
+    }
+
+    if (key === 'gallery-id' || key === 'gallery-src') {
+        if (value === '') return null;
+
+        return [`data-${key}`, value];
+    }
+
+    return key.startsWith('data-') ? [key, value] : null;
 }
 
 function parseInlineAttributes(attrsStr: string): ParsedAttrs {
@@ -356,6 +363,10 @@ function parseInlineAttributes(attrsStr: string): ParsedAttrs {
             result.dataAttrs = result.dataAttrs || {};
             result.dataAttrs[resolved[0]] = resolved[1];
         }
+    }
+
+    if (result.dataAttrs?.['data-gallery-id']) {
+        result.dataAttrs['data-gallery'] = 'true';
     }
 
     // The block is fully ours only if it carries our attributes and nothing

--- a/src/transform/plugins/imsize/plugin.ts
+++ b/src/transform/plugins/imsize/plugin.ts
@@ -293,13 +293,19 @@ type ParsedAttrs = {
 };
 
 function resolveDataAttr(key: string, value: string): [string, string] | null {
-    const isGalleryValid = value === 'true' || value === 'false';
+    if (key === 'gallery' || key === 'data-gallery') {
+        const isGalleryValid = value === 'true' || value === 'false';
 
-    if (key === 'gallery') return isGalleryValid ? ['data-gallery', value] : null;
-    if (key === 'data-gallery') return isGalleryValid ? [key, value] : null;
-    if (key === 'gallery-src') return value !== '' ? ['data-gallery-src', value] : null;
-    if (key.startsWith('data-')) return [key, value];
-    return null;
+        return isGalleryValid ? ['data-gallery', value] : null;
+    }
+
+    if (key === 'gallery-id' || key === 'gallery-src') {
+        if (value === '') return null;
+
+        return [`data-${key}`, value];
+    }
+
+    return key.startsWith('data-') ? [key, value] : null;
 }
 
 function parseInlineAttributes(attrsStr: string): ParsedAttrs {
@@ -327,5 +333,10 @@ function parseInlineAttributes(attrsStr: string): ParsedAttrs {
             result.dataAttrs[resolved[0]] = resolved[1];
         }
     }
+
+    if (result.dataAttrs?.['data-gallery-id']) {
+        result.dataAttrs['data-gallery'] = 'true';
+    }
+
     return result;
 }

--- a/test/gallery.test.ts
+++ b/test/gallery.test.ts
@@ -54,12 +54,12 @@ describe('Images plugin gallery', () => {
     });
 
     test('should handle inline SVG with gallery attribute', () => {
-        const imagePath = resolve(dirname(mocksPath), 'test.svg');
+        const imagePath = resolve(dirname(mocksPath), 'test-gallery.svg');
         const svgContent =
             '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red" /></svg>';
         writeFileSync(imagePath, svgContent);
 
-        const html = transformYfm('![test](./test.svg){inline=true data-gallery=true}');
+        const html = transformYfm('![test](./test-gallery.svg){inline=true data-gallery=true}');
         expect(html).toContain('data-gallery="true"');
 
         unlinkSync(imagePath);
@@ -68,6 +68,48 @@ describe('Images plugin gallery', () => {
     test('should not add gallery attribute when not set md attribute', () => {
         const html = transformYfm('![test](./test.png)');
         expect(html).not.toContain('data-gallery="true"');
+    });
+
+    describe('gallery-id', () => {
+        test('should convert gallery-id attribute into data-gallery-id', () => {
+            const html = transformYfm('![test](./test.png){gallery-id=42}');
+
+            expect(html).toContain('data-gallery-id="42"');
+            expect(html).toContain('data-gallery="true"');
+            expect(html).not.toMatch(/\sgallery-id=/);
+        });
+
+        test.each(['gallery=false gallery-id=42', 'gallery-id=42 gallery=false'])(
+            'should prioritize gallery-id over gallery=false: %s',
+            (attributes) => {
+                const html = transformYfm(`![test](./test.png){${attributes}}`);
+
+                expect(html).toContain('data-gallery-id="42"');
+                expect(html).toContain('data-gallery="true"');
+                expect(html).not.toContain('data-gallery="false"');
+            },
+        );
+
+        test('should not add data-gallery-id when gallery-id is empty', () => {
+            const html = transformYfm('![test](./test.png){gallery-id=}');
+
+            expect(html).not.toContain('data-gallery-id');
+        });
+
+        test('should add data-gallery-id to inline SVG images', () => {
+            const svgPath = resolve(dirname(mocksPath), 'test-gallery-id.svg');
+            const svgContent =
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red" /></svg>';
+
+            writeFileSync(svgPath, svgContent);
+
+            const html = transformYfm('![test](./test-gallery-id.svg){inline=true gallery-id=42}');
+
+            expect(html).toContain('data-gallery-id="42"');
+            expect(html).toContain('data-gallery="true"');
+
+            unlinkSync(svgPath);
+        });
     });
 
     describe('gallery-src', () => {

--- a/test/imsize.test.ts
+++ b/test/imsize.test.ts
@@ -66,6 +66,25 @@ describe('imsize inline attributes {key=value}', () => {
         expect(result).not.toContain('data-gallery=');
     });
 
+    test('converts gallery-id into data-gallery-id', () => {
+        const result = md.render('![test](img.png){gallery-id=42}');
+
+        expect(result).toContain('data-gallery-id="42"');
+        expect(result).toContain('data-gallery="true"');
+        expect(result).not.toMatch(/\sgallery-id=/);
+    });
+
+    test.each(['data-gallery=false gallery-id=42', 'gallery-id=42 data-gallery=false'])(
+        'gallery-id overrides gallery=false regardless of attribute order: %s',
+        (attributes) => {
+            const result = md.render(`![test](img.png){${attributes}}`);
+
+            expect(result).toContain('data-gallery-id="42"');
+            expect(result).toContain('data-gallery="true"');
+            expect(result).not.toContain('data-gallery="false"');
+        },
+    );
+
     test('single-quoted attribute value', () => {
         const result = md.render("![test](img.png){width='150'}");
         expect(result).toContain('width="150"');


### PR DESCRIPTION
## Description

Added support for the gallery-id attribute in md image syntax. 
The attribute is transformed into data-gallery-id, allowing the viewer to group images with the same identifier into a single gallery. Specifying gallery-id also automatically adds data-gallery="true", so the image is included in the gallery regardless of its dimensions. 

This behavior is supported by both the standard image plugin and the imsize inline-attribute parser. If gallery=false and gallery-id are specified together, gallery-id takes precedence. 

Tests cover regular images, inline SVG images, empty values, and attribute-order edge cases.