### PR TITLE
fix(transform): preserve strikethrough around auto-linked URLs #DOCSTOOLS-5243

### DIFF
--- a/src/transform/md.ts
+++ b/src/transform/md.ts
@@ -12,6 +12,7 @@ import extractTitle from './title';
 import getHeadings from './headings';
 import sanitizeHtml, {defaultOptions, sanitizeStyles} from './sanitize';
 import {olAttrConversion} from './plugins/ol-attr-conversion';
+import linkifyStrikethrough from './plugins/linkify-strikethrough';
 import {DEFAULT_LANG} from './constants';
 import {createIDGeneratorByStrategy} from './plugins/utils';
 
@@ -117,6 +118,7 @@ function initPlugins(md: MarkdownIt, options: OptionsType, pluginOptions: Markdo
 
     md.use(olAttrConversion);
 
+    md.use(linkifyStrikethrough);
     plugins.forEach((plugin) => md.use(plugin, pluginOptions));
 
     if (linkify && linkifyTlds) {

--- a/src/transform/plugins/linkify-strikethrough.ts
+++ b/src/transform/plugins/linkify-strikethrough.ts
@@ -62,7 +62,7 @@ function trimMarkdownSuffix(value: string, unmatchedOpeners: Map<number, number>
         const previousEnd = end;
 
         // Preserve the built-in linkify rule's handling of emphasis markers.
-        while (end > 0 && value.charCodeAt(end - 1) === ASTERISK_MARKER) {
+        while (end > 0 && value.codePointAt(end - 1) === ASTERISK_MARKER) {
             end--;
         }
 
@@ -70,8 +70,8 @@ function trimMarkdownSuffix(value: string, unmatchedOpeners: Map<number, number>
         while (
             unmatchedStrikethrough > 0 &&
             end >= 2 &&
-            value.charCodeAt(end - 1) === TILDE_MARKER &&
-            value.charCodeAt(end - 2) === TILDE_MARKER
+            value.codePointAt(end - 1) === TILDE_MARKER &&
+            value.codePointAt(end - 2) === TILDE_MARKER
         ) {
             end -= 2;
             unmatchedStrikethrough--;
@@ -82,7 +82,7 @@ function trimMarkdownSuffix(value: string, unmatchedOpeners: Map<number, number>
         while (
             unmatchedEmphasis > 0 &&
             end > 0 &&
-            value.charCodeAt(end - 1) === UNDERSCORE_MARKER
+            value.codePointAt(end - 1) === UNDERSCORE_MARKER
         ) {
             end--;
             unmatchedEmphasis--;

--- a/src/transform/plugins/linkify-strikethrough.ts
+++ b/src/transform/plugins/linkify-strikethrough.ts
@@ -1,0 +1,135 @@
+import type {Delimiter} from 'markdown-it/lib/rules_inline/state_inline';
+import type StateInline from 'markdown-it/lib/rules_inline/state_inline';
+import type {MarkdownIt} from '../typings';
+
+// Matches the scheme expression used by markdown-it's built-in linkify rule.
+const SCHEME_RE = /(?:^|[^a-z0-9.+-])([a-z][a-z0-9.+-]*)$/i;
+const TILDE_MARKER = 0x7e;
+
+// linkLevel exists at runtime in markdown-it but is missing from the public type.
+type LinkifyState = StateInline & {
+    linkLevel: number;
+};
+
+type LinkifyMatch = NonNullable<ReturnType<MarkdownIt['linkify']['match']>>[number];
+
+// matchAtStart exists in linkify-it but is missing from the installed types.
+type LinkifyWithMatchAtStart = MarkdownIt['linkify'] & {
+    matchAtStart(value: string): LinkifyMatch | null;
+};
+
+type DelimiterScanState = {
+    scannedCount: number;
+    unmatchedOpeners: number;
+};
+
+function hasUnmatchedStrikethroughOpener(
+    delimiters: Delimiter[],
+    scanStates: WeakMap<Delimiter[], DelimiterScanState>,
+) {
+    let scanState = scanStates.get(delimiters);
+    if (!scanState || scanState.scannedCount > delimiters.length) {
+        scanState = {scannedCount: 0, unmatchedOpeners: 0};
+        scanStates.set(delimiters, scanState);
+    }
+
+    // Process only new delimiters to keep the overall scan linear.
+    for (let index = scanState.scannedCount; index < delimiters.length; index++) {
+        const delimiter = delimiters[index];
+        if (delimiter.marker !== TILDE_MARKER) {
+            continue;
+        }
+
+        if (delimiter.close && scanState.unmatchedOpeners > 0) {
+            scanState.unmatchedOpeners--;
+        } else if (delimiter.open) {
+            scanState.unmatchedOpeners++;
+        }
+    }
+
+    scanState.scannedCount = delimiters.length;
+
+    return scanState.unmatchedOpeners > 0;
+}
+
+// The built-in linkify rule also excludes trailing stars from URLs.
+function trimTrailingStars(value: string) {
+    let end = value.length;
+
+    while (end > 0 && value[end - 1] === '*') {
+        end--;
+    }
+
+    return value.slice(0, end);
+}
+
+export default function linkifyStrikethrough(md: MarkdownIt) {
+    // Each inline nesting level has its own delimiter array and scan progress.
+    const delimiterScanStates = new WeakMap<Delimiter[], DelimiterScanState>();
+
+    // Replace the existing rule under the same name so md.disable('linkify') still works.
+    md.inline.ruler.at('linkify', (rawState, silent) => {
+        const state = rawState as LinkifyState;
+        const pos = state.pos;
+
+        if (
+            !state.md.options.linkify ||
+            state.linkLevel > 0 ||
+            pos + 3 > state.posMax ||
+            state.src.codePointAt(pos) !== 0x3a /* : */ ||
+            state.src.codePointAt(pos + 1) !== 0x2f /* / */ ||
+            state.src.codePointAt(pos + 2) !== 0x2f /* / */
+        ) {
+            return false;
+        }
+
+        const schemeMatch = SCHEME_RE.exec(state.pending);
+        if (!schemeMatch) {
+            return false;
+        }
+
+        const scheme = schemeMatch[1];
+        const linkify = state.md.linkify as LinkifyWithMatchAtStart;
+        const link = linkify.matchAtStart(state.src.slice(pos - scheme.length));
+        if (!link) {
+            return false;
+        }
+
+        // Trailing "~~" is markup only when an unmatched opener exists.
+        const hasClosingStrikethroughMarker =
+            link.url.endsWith('~~') &&
+            hasUnmatchedStrikethroughOpener(state.delimiters, delimiterScanStates);
+        const matchedUrl = hasClosingStrikethroughMarker ? link.url.slice(0, -2) : link.url;
+
+        const url = trimTrailingStars(matchedUrl);
+        if (url.length <= scheme.length) {
+            return false;
+        }
+
+        const href = state.md.normalizeLink(url);
+        if (!state.md.validateLink(href)) {
+            return false;
+        }
+
+        // Silent mode checks whether the rule applies without creating tokens.
+        if (!silent) {
+            state.pending = state.pending.slice(0, -scheme.length);
+
+            const linkOpen = state.push('link_open', 'a', 1);
+            linkOpen.attrs = [['href', href]];
+            linkOpen.markup = 'linkify';
+            linkOpen.info = 'auto';
+
+            const linkText = state.push('text', '', 0);
+            linkText.content = state.md.normalizeLinkText(url);
+
+            const linkClose = state.push('link_close', 'a', -1);
+            linkClose.markup = 'linkify';
+            linkClose.info = 'auto';
+        }
+
+        // The scheme is already in pending, so advance only over the rest of the URL.
+        state.pos += url.length - scheme.length;
+        return true;
+    });
+}

--- a/src/transform/plugins/linkify-strikethrough.ts
+++ b/src/transform/plugins/linkify-strikethrough.ts
@@ -4,6 +4,8 @@ import type {MarkdownIt} from '../typings';
 
 // Matches the scheme expression used by markdown-it's built-in linkify rule.
 const SCHEME_RE = /(?:^|[^a-z0-9.+-])([a-z][a-z0-9.+-]*)$/i;
+const ASTERISK_MARKER = 0x2a;
+const UNDERSCORE_MARKER = 0x5f;
 const TILDE_MARKER = 0x7e;
 
 // linkLevel exists at runtime in markdown-it but is missing from the public type.
@@ -20,36 +22,79 @@ type LinkifyWithMatchAtStart = MarkdownIt['linkify'] & {
 
 type DelimiterScanState = {
     scannedCount: number;
-    unmatchedOpeners: number;
+    unmatchedOpeners: Map<number, number>;
 };
 
-function hasUnmatchedStrikethroughOpener(
+function getUnmatchedOpeners(
     delimiters: Delimiter[],
     scanStates: WeakMap<Delimiter[], DelimiterScanState>,
 ) {
     let scanState = scanStates.get(delimiters);
     if (!scanState || scanState.scannedCount > delimiters.length) {
-        scanState = {scannedCount: 0, unmatchedOpeners: 0};
+        scanState = {scannedCount: 0, unmatchedOpeners: new Map()};
         scanStates.set(delimiters, scanState);
     }
 
     // Process only new delimiters to keep the overall scan linear.
     for (let index = scanState.scannedCount; index < delimiters.length; index++) {
         const delimiter = delimiters[index];
-        if (delimiter.marker !== TILDE_MARKER) {
+        if (delimiter.marker !== TILDE_MARKER && delimiter.marker !== UNDERSCORE_MARKER) {
             continue;
         }
 
-        if (delimiter.close && scanState.unmatchedOpeners > 0) {
-            scanState.unmatchedOpeners--;
+        const unmatchedOpeners = scanState.unmatchedOpeners.get(delimiter.marker) || 0;
+        if (delimiter.close && unmatchedOpeners > 0) {
+            scanState.unmatchedOpeners.set(delimiter.marker, unmatchedOpeners - 1);
         } else if (delimiter.open) {
-            scanState.unmatchedOpeners++;
+            scanState.unmatchedOpeners.set(delimiter.marker, unmatchedOpeners + 1);
         }
     }
 
     scanState.scannedCount = delimiters.length;
 
-    return scanState.unmatchedOpeners > 0;
+    return new Map(scanState.unmatchedOpeners);
+}
+
+function trimMarkdownSuffix(value: string, unmatchedOpeners: Map<number, number>) {
+    let end = value.length;
+
+    while (end > 0) {
+        const previousEnd = end;
+
+        // Preserve the built-in linkify rule's handling of emphasis markers.
+        while (end > 0 && value.charCodeAt(end - 1) === ASTERISK_MARKER) {
+            end--;
+        }
+
+        let unmatchedStrikethrough = unmatchedOpeners.get(TILDE_MARKER) || 0;
+        while (
+            unmatchedStrikethrough > 0 &&
+            end >= 2 &&
+            value.charCodeAt(end - 1) === TILDE_MARKER &&
+            value.charCodeAt(end - 2) === TILDE_MARKER
+        ) {
+            end -= 2;
+            unmatchedStrikethrough--;
+        }
+        unmatchedOpeners.set(TILDE_MARKER, unmatchedStrikethrough);
+
+        let unmatchedEmphasis = unmatchedOpeners.get(UNDERSCORE_MARKER) || 0;
+        while (
+            unmatchedEmphasis > 0 &&
+            end > 0 &&
+            value.charCodeAt(end - 1) === UNDERSCORE_MARKER
+        ) {
+            end--;
+            unmatchedEmphasis--;
+        }
+        unmatchedOpeners.set(UNDERSCORE_MARKER, unmatchedEmphasis);
+
+        if (end === previousEnd) {
+            break;
+        }
+    }
+
+    return end;
 }
 
 // The built-in linkify rule also excludes trailing stars from URLs.
@@ -90,18 +135,23 @@ export default function linkifyStrikethrough(md: MarkdownIt) {
 
         const scheme = schemeMatch[1];
         const linkify = state.md.linkify as LinkifyWithMatchAtStart;
-        const link = linkify.matchAtStart(state.src.slice(pos - scheme.length));
+        const linkSource = state.src.slice(pos - scheme.length);
+        let link = linkify.matchAtStart(linkSource);
         if (!link) {
             return false;
         }
 
-        // Trailing "~~" is markup only when an unmatched opener exists.
-        const hasClosingStrikethroughMarker =
-            link.url.endsWith('~~') &&
-            hasUnmatchedStrikethroughOpener(state.delimiters, delimiterScanStates);
-        const matchedUrl = hasClosingStrikethroughMarker ? link.url.slice(0, -2) : link.url;
+        const unmatchedOpeners = getUnmatchedOpeners(state.delimiters, delimiterScanStates);
+        const linkSourceEnd = trimMarkdownSuffix(link.raw, unmatchedOpeners);
+        if (linkSourceEnd < link.raw.length) {
+            // Match again without closing markup so linkify can also restore punctuation boundaries.
+            link = linkify.matchAtStart(linkSource.slice(0, linkSourceEnd));
+            if (!link) {
+                return false;
+            }
+        }
 
-        const url = trimTrailingStars(matchedUrl);
+        const url = trimTrailingStars(link.url);
         if (url.length <= scheme.length) {
             return false;
         }

--- a/test/linkify.test.ts
+++ b/test/linkify.test.ts
@@ -3,6 +3,11 @@ import type {MarkdownIt} from '../src/transform/typings';
 import transform from '../src/transform';
 
 describe('Linkify', () => {
+    const url = 'https://example.com/path';
+    const renderedLink = `<a href="${url}">${url}</a>`;
+    const fencedCode = (fence: string, info = '', content = `~~${url}~~`) =>
+        `${fence}${info}\n${content}\n${fence}`;
+
     it('should not linkify .cloud tld without linkifyTlds option', () => {
         const {
             result: {html},
@@ -21,11 +26,121 @@ describe('Linkify', () => {
     it('should linkify a strikethrough URL without consuming its closing marker', () => {
         const {
             result: {html},
-        } = transform('~~https://example.com/path~~', {linkify: true});
+        } = transform(`~~${url}~~`, {linkify: true});
 
-        expect(html).toBe(
-            '<p><s><a href="https://example.com/path">https://example.com/path</a></s></p>\n',
-        );
+        expect(html).toBe(`<p><s>${renderedLink}</s></p>\n`);
+    });
+
+    it.each([
+        ['**', 'strong'],
+        ['*', 'em'],
+        ['__', 'strong'],
+        ['_', 'em'],
+    ])('should preserve strikethrough inside %s emphasis', (markup, tag) => {
+        const {
+            result: {html},
+        } = transform(`${markup}~~${url}~~${markup}`, {linkify: true});
+
+        expect(html).toBe(`<p><${tag}><s>${renderedLink}</s></${tag}></p>\n`);
+    });
+
+    it.each([
+        ['__', 'strong'],
+        ['_', 'em'],
+    ])('should preserve %s emphasis inside strikethrough', (markup, tag) => {
+        const {
+            result: {html},
+        } = transform(`~~${markup}${url}${markup}~~`, {linkify: true});
+
+        expect(html).toBe(`<p><s><${tag}>${renderedLink}</${tag}></s></p>\n`);
+    });
+
+    it.each(['.', ',', ';', '!', '?', "'"])(
+        'should keep trailing punctuation %s outside the auto-linked URL',
+        (punctuation) => {
+            const {
+                result: {html},
+            } = transform(`~~${url}${punctuation}~~`, {linkify: true});
+
+            expect(html).toBe(`<p><s>${renderedLink}${punctuation}</s></p>\n`);
+        },
+    );
+
+    it.each([
+        {
+            name: 'inline code',
+            source: `\`~~${url}~~\``,
+            expectedFragments: ['<code'],
+        },
+        {
+            name: 'three-backtick fence',
+            source: fencedCode('```'),
+            expectedFragments: ['<pre><code'],
+        },
+        {
+            name: 'four-backtick fence containing three backticks',
+            source: fencedCode('````', '', `\`\`\`\n~~${url}~~\n\`\`\``),
+            expectedFragments: ['<pre><code'],
+        },
+        {
+            name: 'three-tilde fence',
+            source: fencedCode('~~~'),
+            expectedFragments: ['<pre><code'],
+        },
+        {
+            name: 'four-tilde fence containing three tildes',
+            source: fencedCode('~~~~', '', `~~~\n~~${url}~~\n~~~`),
+            expectedFragments: ['<pre><code'],
+        },
+        {
+            name: 'four-space indented block',
+            source: `    ~~${url}~~`,
+            expectedFragments: ['<pre><code'],
+        },
+        {
+            name: 'tab-indented block',
+            source: `\t~~${url}~~`,
+            expectedFragments: ['<pre><code'],
+        },
+        {
+            name: 'fence with a language',
+            source: fencedCode('```', 'text'),
+            expectedFragments: ['class="hljs text"'],
+        },
+        {
+            name: 'four-backtick fence with line numbers',
+            source: fencedCode('````', 'text showLineNumbers'),
+            expectedFragments: ['yfm-line-number'],
+        },
+        {
+            name: 'tilde fence with line wrapping',
+            source: fencedCode('~~~', 'text wrap'),
+            expectedFragments: ['class="hljs text wrap"', 'g-button_selected'],
+        },
+        {
+            name: 'four-tilde fence with a prompt',
+            source: fencedCode('~~~~', 'text prompt="$"', `$ ~~${url}~~`),
+            expectedFragments: ['data-prompt="$"', 'yfm-code-prompt'],
+        },
+        {
+            name: 'fence with all supported parameters',
+            source: fencedCode('```', 'text prompt="$" showLineNumbers wrap', `$ ~~${url}~~`),
+            expectedFragments: [
+                'data-prompt="$"',
+                'yfm-code-prompt',
+                'yfm-line-number',
+                'class="hljs text wrap"',
+                'g-button_selected',
+            ],
+        },
+    ])('should not linkify a strikethrough URL in $name', ({source, expectedFragments}) => {
+        const {
+            result: {html},
+        } = transform(source, {linkify: true, codeLineWrapping: true});
+
+        expect(html).toContain(`~~${url}~~`);
+        expect(html).not.toContain('<a ');
+        expectedFragments.forEach((fragment) => expect(html).toContain(fragment));
     });
 
     it('should preserve a trailing tilde in a strikethrough URL', () => {

--- a/test/linkify.test.ts
+++ b/test/linkify.test.ts
@@ -1,3 +1,5 @@
+import type {MarkdownIt} from '../src/transform/typings';
+
 import transform from '../src/transform';
 
 describe('Linkify', () => {
@@ -14,5 +16,83 @@ describe('Linkify', () => {
         } = transform('yandex.cloud', {linkifyTlds: 'cloud', linkify: true});
 
         expect(html).toMatchSnapshot();
+    });
+
+    it('should linkify a strikethrough URL without consuming its closing marker', () => {
+        const {
+            result: {html},
+        } = transform('~~https://example.com/path~~', {linkify: true});
+
+        expect(html).toBe(
+            '<p><s><a href="https://example.com/path">https://example.com/path</a></s></p>\n',
+        );
+    });
+
+    it('should preserve a trailing tilde in a strikethrough URL', () => {
+        const {
+            result: {html},
+        } = transform('~~https://example.com/~user~~~', {linkify: true});
+
+        expect(html).toBe(
+            '<p><s><a href="https://example.com/~user~">https://example.com/~user~</a></s></p>\n',
+        );
+    });
+
+    it('should preserve trailing tildes outside strikethrough', () => {
+        const {
+            result: {html},
+        } = transform('https://example.com/path~~', {linkify: true});
+
+        expect(html).toBe(
+            '<p><a href="https://example.com/path~~">https://example.com/path~~</a></p>\n',
+        );
+    });
+
+    it('should ignore closed strikethrough before a URL with trailing tildes', () => {
+        const {
+            result: {html},
+        } = transform('~~done~~ https://example.com/path~~', {linkify: true});
+
+        expect(html).toBe(
+            '<p><s>done</s> <a href="https://example.com/path~~">https://example.com/path~~</a></p>\n',
+        );
+    });
+
+    it('should track strikethrough delimiters across multiple URLs', () => {
+        const {
+            result: {html},
+        } = transform(
+            '~~https://example.com/one~~ ~~https://example.com/two~~ https://example.com/three~~',
+            {linkify: true},
+        );
+
+        expect(html).toBe(
+            '<p><s><a href="https://example.com/one">https://example.com/one</a></s> ' +
+                '<s><a href="https://example.com/two">https://example.com/two</a></s> ' +
+                '<a href="https://example.com/three~~">https://example.com/three~~</a></p>\n',
+        );
+    });
+
+    it('should respect the disabled linkify rule', () => {
+        const {
+            result: {html},
+        } = transform('~~https://example.com/path~~', {
+            linkify: true,
+            disableRules: ['linkify'],
+        });
+
+        expect(html).toBe('<p><s>https://example.com/path</s></p>\n');
+    });
+
+    it('should allow a custom plugin to disable the replaced linkify rule', () => {
+        const disableLinkify = (md: MarkdownIt) => md.disable('linkify');
+        const {
+            result: {html},
+        } = transform('~~https://example.com/path~~', {
+            linkify: true,
+            plugins: [disableLinkify],
+        });
+
+        expect(html).toBe('<p><s>https://example.com/path</s></p>\n');
     });
 });


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request, before submitting, please read commit message formatting guidelines at https://www.conventionalcommits.org/en/v1.0.0/

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that the code is up-to-date with the `master` branch.
4. Include a description of the proposed changes and how to test them.

For Russian speaking contributors:
Перед отправкой PR-a, пожалуйста, прочтите гайды для разработчиков платформы Diplodoc : https://diplodoc.com/docs/ru/dev/
#xxxx" -->

## Description

- The handling of auto‑links inside strikethrough text has been fixed: `~~https://...~~` now displays correctly as a strikethrough link.
- An inline rule has been added that prevents `linkify` from consuming the closing `~~`.
- Support for URLs with permissible `~` characters at the end has been retained.
- Regression tests for basic and edge cases have been added.
- The fix has been verified by tests, typecheck, build, and visually via testpack.

Related issue: #DOCSTOOLS-5243

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
