### PR TITLE
fix(yfmlint): utf16 in headers #6545

### DIFF
--- a/src/transform/plugins/anchors/index.ts
+++ b/src/transform/plugins/anchors/index.ts
@@ -76,6 +76,7 @@ const index: MarkdownItPluginCb<Options> = (md, options) => {
         disableCommonAnchors,
         useCommonAnchorButtons,
         lang,
+        isLintRun,
     } = options;
 
     const plugin = (state: StateCore) => {
@@ -129,6 +130,9 @@ const index: MarkdownItPluginCb<Options> = (md, options) => {
                         lower: true,
                         remove: /[^\w\s$_\-,;=/]+/g,
                     });
+                    if (isLintRun && !id) {
+                        token.attrSet('YFM021', 'true');
+                    }
                     ghId = slugger.slug(title);
                 }
 

--- a/test/anchors.test.ts
+++ b/test/anchors.test.ts
@@ -1,5 +1,6 @@
 import {dirname} from 'path';
 import dedent from 'ts-dedent';
+import MarkdownIt from 'markdown-it';
 
 import includes from '../src/transform/plugins/includes';
 import anchors from '../src/transform/plugins/anchors';
@@ -20,6 +21,24 @@ const html = (text: string, opts?: transform.Options) => {
         ...opts,
     });
     return html;
+};
+
+const headingTokens = (text: string, opts: {extractTitle?: boolean; isLintRun?: boolean} = {}) => {
+    const md = new MarkdownIt();
+
+    md.use(anchors, {
+        path: mocksPath,
+        root: dirname(mocksPath),
+        rootPublicPath: '',
+        lang: 'en',
+        log,
+        transformLink: (value: string) => value,
+        extractTitle: true,
+        isLintRun: true,
+        ...opts,
+    });
+
+    return md.parse(text, {}).filter((token) => token.type === 'heading_open');
 };
 
 describe('Anchors', () => {
@@ -223,6 +242,52 @@ describe('Anchors', () => {
                 Content
             `);
             expect(title).toBe('Config <key> reference');
+        });
+    });
+
+    describe('lint markers', () => {
+        it('marks headings with empty automatic anchors', () => {
+            const headings = headingTokens(dedent`
+                ## 😀
+
+                ## ☕
+
+                中文
+                ---
+            `);
+
+            expect(headings).toHaveLength(3);
+            expect(headings.every((token) => token.attrGet('YFM021') === 'true')).toBe(true);
+        });
+
+        it('marks duplicate empty base anchors before adding numeric suffixes', () => {
+            const headings = headingTokens(dedent`
+                ## 😀
+
+                ## 🚀
+            `);
+
+            expect(headings.map((token) => token.attrGet('id'))).toEqual(['', '1']);
+            expect(headings.map((token) => token.attrGet('YFM021'))).toEqual(['true', 'true']);
+        });
+
+        it('does not mark valid automatic, explicit, or extracted title anchors', () => {
+            const headings = headingTokens(dedent`
+                # 😀
+
+                ## Release 🚀 notes
+
+                ## 😀 {#emoji-section}
+            `);
+
+            expect(headings.map((token) => token.attrGet('YFM021'))).toEqual([null, null, null]);
+        });
+
+        it('does not add lint markers during a regular transform', () => {
+            const [heading] = headingTokens('## 😀', {isLintRun: false});
+
+            expect(heading.attrGet('YFM021')).toBeNull();
+            expect(html('## 😀')).not.toContain('YFM021');
         });
     });
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request, before submitting, please read commit message formatting guidelines at https://www.conventionalcommits.org/en/v1.0.0/

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that the code is up-to-date with the `master` branch.
4. Include a description of the proposed changes and how to test them.

For Russian speaking contributors:
Перед отправкой PR-a, пожалуйста, прочтите гайды для разработчиков платформы Diplodoc : https://diplodoc.com/docs/ru/dev/
#xxxx" -->

## Description

- YFM021 now checks only headings with an empty automatic anchor.
- Regular emoji and Unicode characters no longer trigger unnecessary warnings.
- To fix this, it is suggested to add an explicit anchor `{#section-id}`.
- The default YFM021 level is `warn`.
- The rule alias has been changed to `empty-auto-heading-anchor`.
- VSC and CLI use the same check via the anchors plugin.

Linked:

- https://github.com/diplodoc-platform/vsc/pull/224
- https://github.com/diplodoc-platform/yfmlint/pull/84
- https://github.com/diplodoc-platform/docs/pull/331

Related issue: #6545

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
